### PR TITLE
Add NPP change asset

### DIFF
--- a/cloud_functions/earth_engine_tiler/src/earth-engine-utils.ts
+++ b/cloud_functions/earth_engine_tiler/src/earth-engine-utils.ts
@@ -16,7 +16,7 @@ export class EarthEngineUtils {
 
       ee.data.authenticateViaPrivateKey(PRIVATE_KEY,
         () => ee.initialize(null, null, resolve, reject),
-        (error: any) => console.error(error),
+        (error: any) => console.error(error), //should it have reject here????
       );
     });
   }

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/anthropogenic-biomes.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/anthropogenic-biomes.ts
@@ -8,7 +8,7 @@ export const AnthropogenicBiomes: EarthEngineImage = {
 
   bandName: 'b1',
 
-  sldStyles: '<RasterSymbolizer>' + 
+  sldStyles: '<RasterSymbolizer>' +
   '<ColorMap type="values" extended="false">' +
     '<ColorMapEntry color="#A80000" quantity="11" />' + // Urban
     '<ColorMapEntry color="#FF0000" quantity="12" />' + // Mixed settlements
@@ -31,7 +31,8 @@ export const AnthropogenicBiomes: EarthEngineImage = {
     '<ColorMapEntry color="#E1E1E1" quantity="62" />' + // Wild treeless and barren lands
   '</ColorMap>' + '</RasterSymbolizer>',
 
-  isYearValid (year?: number) : boolean {
+  areYearsValid (startYear?: number, endYear?: number) : boolean {
+    //This Asset is static, and year selector are irrelevant
     return true;
   },
 

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/earth-engine-dataset.d.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/earth-engine-dataset.d.ts
@@ -4,14 +4,14 @@ export interface EarthEngineDataset {
 
   // Performs validation of the year, intended for use with Assets that require a year
   // If not valid, an error should be thrown
-  isYearValid: (year?: number) => boolean;
+  areYearsValid: (startYear?: number, endYear?: number) => boolean;
 
   // Function that returns ee.Image instance with asset
   getEEAsset: (key?: string) => any;
-  getMapUrl: (z: number, x: number, y: number, year?: number) => any;
+  getMapUrl: (z: number, x: number, y: number, startYear?: number, endYear?: number) => any;
 }
 
-interface EarthEngineCollection extends EarthEngineDataset {
+export interface EarthEngineCollection extends EarthEngineDataset {
   /** Visualization parameters */
   readonly vizParams: {
     bands: string[],
@@ -21,7 +21,7 @@ interface EarthEngineCollection extends EarthEngineDataset {
   };
 }
 
-interface EarthEngineImage extends EarthEngineDataset {
+export interface EarthEngineImage extends EarthEngineDataset {
   /** Band names */
   readonly bandName: string;
 

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/modis-net-primary-production-change.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/modis-net-primary-production-change.ts
@@ -1,0 +1,40 @@
+import { EarthEngineCollection } from './earth-engine-dataset';
+import ee from '@google/earthengine';
+
+
+export const ModisNetPrimaryProductionChange: EarthEngineCollection = {
+  assetPath: {
+    default: "MODIS/061/MOD17A3HGF"
+  },
+
+  vizParams: {
+    bands: ['Npp'],
+    min: -5000,
+    max: 5000,
+    palette: ["#B30200", '#FFFFCC', '#066C59']
+  },
+
+  isYearValid (year?: number) : boolean {
+    if(!year){
+      throw new Error(`Year '${year}' is not valid`)
+    }
+    return true;
+  },
+
+  getEEAsset() {
+    return ee.ImageCollection(this.assetPath.default);
+  },
+
+  getMapUrl(z, x, y, year) {
+
+    const image_start = this.getEEAsset()
+    .filter( ee.Filter.date( `${String(2001)}-01-01`, `${String(2001)}-12-31` ) ).first();
+
+    const image_end = this.getEEAsset()
+      .filter( ee.Filter.date( `${String(year)}-01-01`, `${String(year)}-12-31` ) ).first();
+
+    const image = image_end.subtract(image_start)
+
+    return ee.data.getTileUrl( image.getMapId(this.vizParams), x, y, z );
+  },
+};

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/modis-net-primary-production-change.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/modis-net-primary-production-change.ts
@@ -14,9 +14,12 @@ export const ModisNetPrimaryProductionChange: EarthEngineCollection = {
     palette: ["#B30200", '#FFFFCC', '#066C59']
   },
 
-  isYearValid (year?: number) : boolean {
-    if(!year){
-      throw new Error(`Year '${year}' is not valid`)
+  areYearsValid (startYear?: number, endYear?: number) : boolean {
+    if(!startYear){
+      throw new Error(`startYear '${startYear}' is not valid`)
+    }
+    if(!endYear){
+      throw new Error(`endYear '${endYear}' is not valid`)
     }
     return true;
   },
@@ -25,13 +28,15 @@ export const ModisNetPrimaryProductionChange: EarthEngineCollection = {
     return ee.ImageCollection(this.assetPath.default);
   },
 
-  getMapUrl(z, x, y, year) {
+  getMapUrl(z, x, y, startYear, endYear) {
 
     const image_start = this.getEEAsset()
-    .filter( ee.Filter.date( `${String(2001)}-01-01`, `${String(2001)}-12-31` ) ).first();
+      .filter( ee.Filter.date( `${String(startYear)}-01-01`, `${String(startYear)}-12-31` ) )
+      .first();
 
     const image_end = this.getEEAsset()
-      .filter( ee.Filter.date( `${String(year)}-01-01`, `${String(year)}-12-31` ) ).first();
+      .filter( ee.Filter.date( `${String(endYear)}-01-01`, `${String(endYear)}-12-31` ) )
+      .first();
 
     const image = image_end.subtract(image_start)
 

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/modis-net-primary-production-dataset.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/modis-net-primary-production-dataset.ts
@@ -14,9 +14,11 @@ export const ModisNetPrimaryProductionDataset: EarthEngineCollection = {
     palette: ['bbe029', '0a9501', '074b03']
   },
 
-  isYearValid (year?: number) : boolean {
-    if(!year){
-      throw new Error(`Year '${year}' is not valid`)
+  areYearsValid (startYear, endYear) : boolean {
+    //This Asset is meant for tiles of a single year. startYear only will be used as the selector for the info required
+    // endYear is unneeded and ignored
+    if(!startYear){
+      throw new Error(`Year '${startYear}' is not valid`)
     }
     return true;
   },
@@ -25,9 +27,9 @@ export const ModisNetPrimaryProductionDataset: EarthEngineCollection = {
     return ee.ImageCollection(this.assetPath.default);
   },
 
-  getMapUrl(z, x, y, year) {
+  getMapUrl(z, x, y, startYear, endYear) {
     const image = this.getEEAsset()
-      .filter( ee.Filter.date( `${String(year)}-01-01`, `${String(year)}-12-31` ) );
+      .filter( ee.Filter.date( `${String(startYear)}-01-01`, `${String(startYear)}-12-31` ) );
     return ee.data.getTileUrl( image.getMapId(this.vizParams), x, y, z );
   },
 };

--- a/cloud_functions/earth_engine_tiler/src/index.ts
+++ b/cloud_functions/earth_engine_tiler/src/index.ts
@@ -53,19 +53,19 @@ router.get('/:z/:x/:y', async (req: Request, res: Response) : Promise<void> => {
       throw new Error(`Tileset ${tileRequestDTO.tileset} not found`);
     }
 
-    asset.isYearValid(tileRequestDTO.year); //Year might be required or not depending on the asset
+    asset.areYearsValid(tileRequestDTO.startYear, tileRequestDTO.endYear); //Year might be required or not depending on the asset
   } catch (errors) {
     sendErrorResponse(res, logId, 400, errors)
     return;
   }
 
-  const { tileset, x, y, z, year } = tileRequestDTO;
-  console.log(`${logId} - Requesting tile for ${tileset} with coordinates ${x}-${y}-${z} and year ${year || 'N/A'}`)
+  const { tileset, x, y, z, startYear, endYear } = tileRequestDTO;
+  console.log(`${logId} - Requesting tile for ${tileset} with coordinates ${x}-${y}-${z} and startYear ${startYear || 'N/A'} / endYear ${endYear || 'N/A'}`)
 
   try {
     await EarthEngineUtils.authenticate();
 
-    const tileURL = await asset.getMapUrl(z, x, y, year);
+    const tileURL = await asset.getMapUrl(z, x, y, startYear, endYear);
     console.log(`${logId} - Obtained tile URL on ${tileURL}`)
     //TODO CACHING
     // The calculations when requesting the tile URL take the longest, images are not probably going to be very big (not even MBs)

--- a/cloud_functions/earth_engine_tiler/src/index.ts
+++ b/cloud_functions/earth_engine_tiler/src/index.ts
@@ -4,6 +4,7 @@ import 'reflect-metadata';
 import {plainToClass} from 'class-transformer';
 import {EarthEngineUtils} from './earth-engine-utils';
 import {ModisNetPrimaryProductionDataset} from './geeAssets/modis-net-primary-production-dataset';
+import {ModisNetPrimaryProductionChange} from './geeAssets/modis-net-primary-production-change';
 import {AnthropogenicBiomes} from './geeAssets/anthropogenic-biomes';
 import {EarthEngineDataset} from "./geeAssets/earth-engine-dataset";
 import {TileRequestDTO, Tilesets} from "./tile-request.dto";
@@ -14,6 +15,7 @@ import * as crypto from "crypto";
 //Asset Mapping
 const assets: Record<Tilesets, EarthEngineDataset> = {
   [Tilesets.modis_net_primary_production]: ModisNetPrimaryProductionDataset,
+  [Tilesets.modis_net_primary_production_change]: ModisNetPrimaryProductionChange,
   [Tilesets.anthropogenic_biomes]: AnthropogenicBiomes
 }
 

--- a/cloud_functions/earth_engine_tiler/src/tile-request.dto.ts
+++ b/cloud_functions/earth_engine_tiler/src/tile-request.dto.ts
@@ -31,5 +31,10 @@ export class TileRequestDTO {
   @IsOptional()
   @Type(()=>Number)
   @IsInt()
-  year?: number;
+  startYear?: number;
+
+  @IsOptional()
+  @Type(()=>Number)
+  @IsInt()
+  endYear?: number;
 }

--- a/cloud_functions/earth_engine_tiler/src/tile-request.dto.ts
+++ b/cloud_functions/earth_engine_tiler/src/tile-request.dto.ts
@@ -3,6 +3,7 @@ import {Type} from "class-transformer";
 
 export enum Tilesets {
   modis_net_primary_production = "modis_net_primary_production",
+  modis_net_primary_production_change = "modis_net_primary_production_change",
   anthropogenic_biomes = "anthropogenic_biomes"
 }
 


### PR DESCRIPTION
Hi @KevSanchez!
I have added the Net Primary Production (NPP) change layer to the cloud function. The layer requires both a **startYear** and an **endYear**. Currently, I am using the current **year** as the **endYear** and have hardcoded the **startYear**. Please update this to allow for dynamic input of both **startYear** and **endYear**. Thank you.