### PR TITLE
Grass 356 environmental justice layer

### DIFF
--- a/client/src/components/map/layers/deck-layer/ej-atlas-component.tsx
+++ b/client/src/components/map/layers/deck-layer/ej-atlas-component.tsx
@@ -26,25 +26,29 @@ interface FeatureWithProps {
 }
 
 const fillColorMap: Record<string, [number, number, number, number]> = {
-  "Fossil fuels and climate justice energy": [26, 33, 162, 255],
-  "Biomass and land conflicts forests agriculture and livestock management": [147, 81, 26, 255],
+  "Fossil Fuels and Climate Justice/Energy": [26, 33, 162, 255],
+  "Biomass and land conflicts (Forests, agriculture, fisheries and livestock management)": [
+    147, 81, 26, 255,
+  ],
   "Biodiversity conservation conflicts": [99, 182, 103, 255],
-  "Water management": [36, 117, 204, 255],
-  "Tourism recreation": [142, 64, 191, 255],
-  "Infrastructure and built environment": [231, 170, 90, 255],
-  "Waste management": [82, 128, 85, 255],
-  "Industrial and utilities conflicts": [223, 106, 67, 255],
-  "Mineral ores and building materials extraction": [239, 159, 159, 255],
-  Nuclear: [144, 119, 4, 255],
+  "Water Management": [36, 117, 204, 255],
+  "Tourism Recreation": [142, 64, 191, 255],
+  "Infrastructure and built environment": [224, 200, 41, 255],
+  "Waste Management": [82, 128, 85, 255],
+  "Industrial and utilities conflicts": [233, 67, 12, 255],
+  "Mineral Ores and Building Materials Extraction": [239, 159, 159, 255],
+  Nuclear: [224, 200, 41, 255],
   Other: [102, 102, 102, 255],
 };
+
 const lineColorMap: Record<string, [number, number, number, number]> = {
   KNOWN: [0, 0, 0, 255],
   LATENT: [49, 181, 246, 255],
   LOW: [225, 192, 71, 255],
-  MEDIUM: [229, 143, 31, 255],
-  HIGH: [218, 62, 62, 255],
+  MEDIUM: [218, 62, 62, 255],
+  HIGH: [105, 7, 7, 255],
 };
+
 export interface EjAtlasLayerComponentProps {
   id: string;
   data: string;

--- a/client/src/components/map/legends/sortable/index.tsx
+++ b/client/src/components/map/legends/sortable/index.tsx
@@ -43,10 +43,12 @@ type SortableListProps = PropsWithChildren & {
 
 import SortableItem from "./item";
 import { LegendItemProps } from "@/containers/map/legends/item";
+import { useSyncLayersSettings } from "@/store/map";
 
 export const SortableList = ({ children, onChangeOrder }: SortableListProps) => {
   const uid = useId();
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+  const [layersSettings, setLayersSettings] = useSyncLayersSettings();
 
   const ActiveItem = useMemo(() => {
     const activeChildArray = Children.map(children, (Child) => {
@@ -104,6 +106,23 @@ export const SortableList = ({ children, onChangeOrder }: SortableListProps) => 
           const newArr = arrayMove(itemsIds || [], oldIndex, newIndex);
           onChangeOrder(newArr);
         }
+      }
+
+      if (active.id === "environmental-justice" || over?.id === "environmental-justice") {
+        setLayersSettings((prev) => {
+          if (!active.id || !over?.id) return prev;
+          return {
+            ...prev,
+            [active.id]: {
+              ...(prev ? prev[active.id] : {}),
+              beforeIdIndex: null,
+            },
+            [over.id]: {
+              ...(prev ? prev[over.id] : {}),
+              beforeIdIndex: null,
+            },
+          };
+        });
       }
     },
     [itemsIds, onChangeOrder],

--- a/client/src/containers/datasets/item.tsx
+++ b/client/src/containers/datasets/item.tsx
@@ -2,7 +2,7 @@
 
 import { DatasetListResponseDataItem } from "@/types/generated/strapi.schemas";
 
-import { useSyncDatasets, useSyncLayers } from "@/store/map";
+import { useSyncDatasets, useSyncLayers, useSyncLayersSettings } from "@/store/map";
 import { Switch } from "@/components/ui/switch";
 import CitationsIcon from "@/svgs/citations.svg";
 import { cn } from "@/lib/utils";
@@ -15,6 +15,7 @@ import TemporalChangesDataset from "./components/temporal";
 import { useGetLayers } from "@/types/generated/layer";
 import { useGetLocalizedList } from "@/lib/localized-query";
 import TemporalGroupDataset from "./components/temporal-group";
+import { before } from "node:test";
 
 type DatasetsItemProps = DatasetListResponseDataItem & {
   className?: string;
@@ -23,10 +24,12 @@ type DatasetsItemProps = DatasetListResponseDataItem & {
 
 type LocalizedGroupProps = "group_es" | "group_fr";
 
+const LAYERS_EXCEPTIONS = ["environmental-justice"];
+
 const DatasetsItem = ({ attributes, className, showTitle }: DatasetsItemProps) => {
   const t = useTranslations();
   const [datasets, setDatasets] = useSyncDatasets();
-  // const [layersSettings, setLayersSettings] = useSyncLayersSettings();
+  const [layersSettings, setLayersSettings] = useSyncLayersSettings();
   const [, setLayers] = useSyncLayers();
   const id = attributes?.slug;
 
@@ -86,6 +89,18 @@ const DatasetsItem = ({ attributes, className, showTitle }: DatasetsItemProps) =
       const firstDatasetLayer = layersData?.[0]?.attributes?.slug;
       if (firstDatasetLayer) {
         setLayers((prev) => [...prev, firstDatasetLayer]);
+      }
+      if (LAYERS_EXCEPTIONS.includes(id)) {
+        setLayersSettings((prev) => {
+          if (!id) return prev;
+          return {
+            ...prev,
+            [id]: {
+              ...(prev ? prev[id] : {}),
+              beforeIdIndex: 0,
+            },
+          };
+        });
       }
     }
   };

--- a/client/src/containers/map/layer-manager/index.tsx
+++ b/client/src/containers/map/layer-manager/index.tsx
@@ -81,11 +81,12 @@ const LayerManager = () => {
         {layers.map((l) => {
           const id = l;
           const beforeId = `${l}-background-layer`;
+          console.log(layersSettings?.[id], layersSettings);
           return (
             <LayerManagerItem
               key={id}
               id={id}
-              beforeId={beforeId}
+              {...(layersSettings?.[id]?.beforeIdIndex !== 0 && { beforeId: beforeId })}
               settings={{
                 // ...{ opacity: 1, visibility: true },
                 ...(!!layersSettings && layersSettings[l]),

--- a/client/src/containers/map/layer-manager/item.tsx
+++ b/client/src/containers/map/layer-manager/item.tsx
@@ -51,7 +51,6 @@ const LayerManagerItem = ({ id, beforeId, settings }: LayerManagerItemProps) => 
   if (isValidElement(c)) {
     return cloneElement(c, { id, key: `${id}-layer` });
   }
-
   return <DeckLayer key={`${id}-layer`} id={id} beforeId={beforeId} config={c} />;
 };
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to map layer management and styling, especially focusing on the handling of the "environmental-justice" layer and enhancements to color mapping for map features. The changes ensure consistent layer ordering, update visual styles, and improve state management for layer settings.

**Layer ordering and settings management:**

* Added logic in `DatasetsItem` to always set the `beforeIdIndex` to `0` for the "environmental-justice" layer when it is added, ensuring it appears at the correct position in the layer stack (`client/src/containers/datasets/item.tsx`). [[1]](diffhunk://#diff-820bf3eb1e2bbdd9f1c2239ababa4368a5159ba93b59be73f5ce56bc113183caR27-R32) [[2]](diffhunk://#diff-820bf3eb1e2bbdd9f1c2239ababa4368a5159ba93b59be73f5ce56bc113183caR93-R104)
* Updated the sortable legend to reset the `beforeIdIndex` to `null` for both the active and target items when "environmental-justice" is involved in a drag-and-drop operation, keeping the order logic consistent (`client/src/components/map/legends/sortable/index.tsx`).
* Modified the `LayerManager` to only pass the `beforeId` prop if `beforeIdIndex` is not `0`, preventing unnecessary prop passing and ensuring correct layer stacking (`client/src/containers/map/layer-manager/index.tsx`).

**Visual and color mapping updates:**

* Standardized and updated the color mappings for various map feature categories, improving consistency and visual clarity on the map (`client/src/components/map/layers/deck-layer/ej-atlas-component.tsx`).

**State management improvements:**

* Ensured `useSyncLayersSettings` is imported and used where needed for consistent state handling of layer settings (`client/src/containers/datasets/item.tsx`, `client/src/components/map/legends/sortable/index.tsx`). [[1]](diffhunk://#diff-820bf3eb1e2bbdd9f1c2239ababa4368a5159ba93b59be73f5ce56bc113183caL5-R5) [[2]](diffhunk://#diff-9cf619f1dfb5d25daebdde4206a88b73e9e05a1d39b6be0e72e268851fc8fa5bR46-R51)

These changes collectively improve the reliability and maintainability of the map's layer ordering and styling logic.