### PR TITLE
feat(story): replace location string with latitude and longitude

### DIFF
--- a/client/src/types/generated/dataset-category.ts
+++ b/client/src/types/generated/dataset-category.ts
@@ -4,7 +4,10 @@
  * DOCUMENTATION
  * OpenAPI spec version: 1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query'
 import type {
   MutationFunction,
   QueryFunction,
@@ -12,361 +15,290 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query'
 import type {
   DatasetCategoryListResponse,
   DatasetCategoryRequest,
   DatasetCategoryResponse,
   Error,
   GetDatasetCategoriesIdParams,
-  GetDatasetCategoriesParams,
-} from "./strapi.schemas";
-import { API } from "../../services/api/index";
-import type { ErrorType } from "../../services/api/index";
+  GetDatasetCategoriesParams
+} from './strapi.schemas'
+import { API } from '../../services/api/index';
+import type { ErrorType } from '../../services/api/index';
+
+
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
+
 export const getDatasetCategories = (
-  params?: GetDatasetCategoriesParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+    params?: GetDatasetCategoriesParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<DatasetCategoryListResponse>(
-    { url: `/dataset-categories`, method: "GET", params, signal },
-    options,
-  );
-};
+      
+      
+      return API<DatasetCategoryListResponse>(
+      {url: `/dataset-categories`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetDatasetCategoriesQueryKey = (params?: GetDatasetCategoriesParams) => {
-  return [`/dataset-categories`, ...(params ? [params] : [])] as const;
-};
+export const getGetDatasetCategoriesQueryKey = (params?: GetDatasetCategoriesParams,) => {
+    return [`/dataset-categories`, ...(params ? [params]: [])] as const;
+    }
 
-export const getGetDatasetCategoriesQueryOptions = <
-  TData = Awaited<ReturnType<typeof getDatasetCategories>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetDatasetCategoriesParams,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategories>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof API>;
-  },
+    
+export const getGetDatasetCategoriesQueryOptions = <TData = Awaited<ReturnType<typeof getDatasetCategories>>, TError = ErrorType<Error>>(params?: GetDatasetCategoriesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategories>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetDatasetCategoriesQueryKey(params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasetCategories>>> = ({ signal }) =>
-    getDatasetCategories(params, requestOptions, signal);
+  const queryKey =  queryOptions?.queryKey ?? getGetDatasetCategoriesQueryKey(params);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getDatasetCategories>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+  
 
-export type GetDatasetCategoriesQueryResult = NonNullable<
-  Awaited<ReturnType<typeof getDatasetCategories>>
->;
-export type GetDatasetCategoriesQueryError = ErrorType<Error>;
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasetCategories>>> = ({ signal }) => getDatasetCategories(params, requestOptions, signal);
 
-export const useGetDatasetCategories = <
-  TData = Awaited<ReturnType<typeof getDatasetCategories>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetDatasetCategoriesParams,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategories>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetDatasetCategoriesQueryOptions(params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+      
 
-  query.queryKey = queryOptions.queryKey;
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategories>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetDatasetCategoriesQueryResult = NonNullable<Awaited<ReturnType<typeof getDatasetCategories>>>
+export type GetDatasetCategoriesQueryError = ErrorType<Error>
+
+export const useGetDatasetCategories = <TData = Awaited<ReturnType<typeof getDatasetCategories>>, TError = ErrorType<Error>>(
+ params?: GetDatasetCategoriesParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategories>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetDatasetCategoriesQueryOptions(params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const postDatasetCategories = (
-  datasetCategoryRequest: DatasetCategoryRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<DatasetCategoryResponse>(
-    {
-      url: `/dataset-categories`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: datasetCategoryRequest,
+    datasetCategoryRequest: DatasetCategoryRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<DatasetCategoryResponse>(
+      {url: `/dataset-categories`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: datasetCategoryRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPostDatasetCategoriesMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postDatasetCategories>>,
-    TError,
-    { data: DatasetCategoryRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof postDatasetCategories>>,
-  TError,
-  { data: DatasetCategoryRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof postDatasetCategories>>,
-    { data: DatasetCategoryRequest }
-  > = (props) => {
-    const { data } = props ?? {};
+export const getPostDatasetCategoriesMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postDatasetCategories>>, TError,{data: DatasetCategoryRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof postDatasetCategories>>, TError,{data: DatasetCategoryRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return postDatasetCategories(data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PostDatasetCategoriesMutationResult = NonNullable<
-  Awaited<ReturnType<typeof postDatasetCategories>>
->;
-export type PostDatasetCategoriesMutationBody = DatasetCategoryRequest;
-export type PostDatasetCategoriesMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postDatasetCategories>>, {data: DatasetCategoryRequest}> = (props) => {
+          const {data} = props ?? {};
 
-export const usePostDatasetCategories = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postDatasetCategories>>,
-    TError,
-    { data: DatasetCategoryRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof postDatasetCategories>>,
-  TError,
-  { data: DatasetCategoryRequest },
-  TContext
-> => {
-  const mutationOptions = getPostDatasetCategoriesMutationOptions(options);
+          return  postDatasetCategories(data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const getDatasetCategoriesId = (
-  id: number,
-  params?: GetDatasetCategoriesIdParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostDatasetCategoriesMutationResult = NonNullable<Awaited<ReturnType<typeof postDatasetCategories>>>
+    export type PostDatasetCategoriesMutationBody = DatasetCategoryRequest
+    export type PostDatasetCategoriesMutationError = ErrorType<Error>
+
+    export const usePostDatasetCategories = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postDatasetCategories>>, TError,{data: DatasetCategoryRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof postDatasetCategories>>,
+        TError,
+        {data: DatasetCategoryRequest},
+        TContext
+      > => {
+
+      const mutationOptions = getPostDatasetCategoriesMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    export const getDatasetCategoriesId = (
+    id: number,
+    params?: GetDatasetCategoriesIdParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<DatasetCategoryResponse>(
-    { url: `/dataset-categories/${id}`, method: "GET", params, signal },
-    options,
-  );
-};
+      
+      
+      return API<DatasetCategoryResponse>(
+      {url: `/dataset-categories/${id}`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetDatasetCategoriesIdQueryKey = (
-  id: number,
-  params?: GetDatasetCategoriesIdParams,
+export const getGetDatasetCategoriesIdQueryKey = (id: number,
+    params?: GetDatasetCategoriesIdParams,) => {
+    return [`/dataset-categories/${id}`, ...(params ? [params]: [])] as const;
+    }
+
+    
+export const getGetDatasetCategoriesIdQueryOptions = <TData = Awaited<ReturnType<typeof getDatasetCategoriesId>>, TError = ErrorType<Error>>(id: number,
+    params?: GetDatasetCategoriesIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategoriesId>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  return [`/dataset-categories/${id}`, ...(params ? [params] : [])] as const;
-};
 
-export const getGetDatasetCategoriesIdQueryOptions = <
-  TData = Awaited<ReturnType<typeof getDatasetCategoriesId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetDatasetCategoriesIdParams,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategoriesId>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof API>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetDatasetCategoriesIdQueryKey(id, params);
+  const queryKey =  queryOptions?.queryKey ?? getGetDatasetCategoriesIdQueryKey(id,params);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasetCategoriesId>>> = ({ signal }) =>
-    getDatasetCategoriesId(id, params, requestOptions, signal);
+  
 
-  return { queryKey, queryFn, enabled: !!id, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getDatasetCategoriesId>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasetCategoriesId>>> = ({ signal }) => getDatasetCategoriesId(id,params, requestOptions, signal);
 
-export type GetDatasetCategoriesIdQueryResult = NonNullable<
-  Awaited<ReturnType<typeof getDatasetCategoriesId>>
->;
-export type GetDatasetCategoriesIdQueryError = ErrorType<Error>;
+      
 
-export const useGetDatasetCategoriesId = <
-  TData = Awaited<ReturnType<typeof getDatasetCategoriesId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetDatasetCategoriesIdParams,
-  options?: {
-    query?: Partial<
-      UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategoriesId>>, TError, TData>
-    >;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetDatasetCategoriesIdQueryOptions(id, params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategoriesId>>, TError, TData> & { queryKey: QueryKey }
+}
 
-  query.queryKey = queryOptions.queryKey;
+export type GetDatasetCategoriesIdQueryResult = NonNullable<Awaited<ReturnType<typeof getDatasetCategoriesId>>>
+export type GetDatasetCategoriesIdQueryError = ErrorType<Error>
+
+export const useGetDatasetCategoriesId = <TData = Awaited<ReturnType<typeof getDatasetCategoriesId>>, TError = ErrorType<Error>>(
+ id: number,
+    params?: GetDatasetCategoriesIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetCategoriesId>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetDatasetCategoriesIdQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const putDatasetCategoriesId = (
-  id: number,
-  datasetCategoryRequest: DatasetCategoryRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<DatasetCategoryResponse>(
-    {
-      url: `/dataset-categories/${id}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: datasetCategoryRequest,
+    id: number,
+    datasetCategoryRequest: DatasetCategoryRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<DatasetCategoryResponse>(
+      {url: `/dataset-categories/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: datasetCategoryRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPutDatasetCategoriesIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putDatasetCategoriesId>>,
-    TError,
-    { id: number; data: DatasetCategoryRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof putDatasetCategoriesId>>,
-  TError,
-  { id: number; data: DatasetCategoryRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof putDatasetCategoriesId>>,
-    { id: number; data: DatasetCategoryRequest }
-  > = (props) => {
-    const { id, data } = props ?? {};
+export const getPutDatasetCategoriesIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putDatasetCategoriesId>>, TError,{id: number;data: DatasetCategoryRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof putDatasetCategoriesId>>, TError,{id: number;data: DatasetCategoryRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return putDatasetCategoriesId(id, data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PutDatasetCategoriesIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof putDatasetCategoriesId>>
->;
-export type PutDatasetCategoriesIdMutationBody = DatasetCategoryRequest;
-export type PutDatasetCategoriesIdMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof putDatasetCategoriesId>>, {id: number;data: DatasetCategoryRequest}> = (props) => {
+          const {id,data} = props ?? {};
 
-export const usePutDatasetCategoriesId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putDatasetCategoriesId>>,
-    TError,
-    { id: number; data: DatasetCategoryRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof putDatasetCategoriesId>>,
-  TError,
-  { id: number; data: DatasetCategoryRequest },
-  TContext
-> => {
-  const mutationOptions = getPutDatasetCategoriesIdMutationOptions(options);
+          return  putDatasetCategoriesId(id,data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const deleteDatasetCategoriesId = (id: number, options?: SecondParameter<typeof API>) => {
-  return API<number>({ url: `/dataset-categories/${id}`, method: "DELETE" }, options);
-};
+        
 
-export const getDeleteDatasetCategoriesIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteDatasetCategoriesId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof deleteDatasetCategoriesId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof deleteDatasetCategoriesId>>,
-    { id: number }
-  > = (props) => {
-    const { id } = props ?? {};
+  return  { mutationFn, ...mutationOptions }}
 
-    return deleteDatasetCategoriesId(id, requestOptions);
-  };
+    export type PutDatasetCategoriesIdMutationResult = NonNullable<Awaited<ReturnType<typeof putDatasetCategoriesId>>>
+    export type PutDatasetCategoriesIdMutationBody = DatasetCategoryRequest
+    export type PutDatasetCategoriesIdMutationError = ErrorType<Error>
 
-  return { mutationFn, ...mutationOptions };
-};
+    export const usePutDatasetCategoriesId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putDatasetCategoriesId>>, TError,{id: number;data: DatasetCategoryRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof putDatasetCategoriesId>>,
+        TError,
+        {id: number;data: DatasetCategoryRequest},
+        TContext
+      > => {
 
-export type DeleteDatasetCategoriesIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof deleteDatasetCategoriesId>>
->;
+      const mutationOptions = getPutDatasetCategoriesIdMutationOptions(options);
 
-export type DeleteDatasetCategoriesIdMutationError = ErrorType<Error>;
+      return useMutation(mutationOptions);
+    }
+    export const deleteDatasetCategoriesId = (
+    id: number,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<number>(
+      {url: `/dataset-categories/${id}`, method: 'DELETE'
+    },
+      options);
+    }
+  
 
-export const useDeleteDatasetCategoriesId = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteDatasetCategoriesId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof deleteDatasetCategoriesId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const mutationOptions = getDeleteDatasetCategoriesIdMutationOptions(options);
 
-  return useMutation(mutationOptions);
-};
+export const getDeleteDatasetCategoriesIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteDatasetCategoriesId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof deleteDatasetCategoriesId>>, TError,{id: number}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteDatasetCategoriesId>>, {id: number}> = (props) => {
+          const {id} = props ?? {};
+
+          return  deleteDatasetCategoriesId(id,requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type DeleteDatasetCategoriesIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteDatasetCategoriesId>>>
+    
+    export type DeleteDatasetCategoriesIdMutationError = ErrorType<Error>
+
+    export const useDeleteDatasetCategoriesId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteDatasetCategoriesId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof deleteDatasetCategoriesId>>,
+        TError,
+        {id: number},
+        TContext
+      > => {
+
+      const mutationOptions = getDeleteDatasetCategoriesIdMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    

--- a/client/src/types/generated/dataset.ts
+++ b/client/src/types/generated/dataset.ts
@@ -4,7 +4,10 @@
  * DOCUMENTATION
  * OpenAPI spec version: 1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query'
 import type {
   MutationFunction,
   QueryFunction,
@@ -12,333 +15,290 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query'
 import type {
   DatasetListResponse,
   DatasetRequest,
   DatasetResponse,
   Error,
   GetDatasetsIdParams,
-  GetDatasetsParams,
-} from "./strapi.schemas";
-import { API } from "../../services/api/index";
-import type { ErrorType } from "../../services/api/index";
+  GetDatasetsParams
+} from './strapi.schemas'
+import { API } from '../../services/api/index';
+import type { ErrorType } from '../../services/api/index';
+
+
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
+
 export const getDatasets = (
-  params?: GetDatasetsParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+    params?: GetDatasetsParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<DatasetListResponse>({ url: `/datasets`, method: "GET", params, signal }, options);
-};
+      
+      
+      return API<DatasetListResponse>(
+      {url: `/datasets`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetDatasetsQueryKey = (params?: GetDatasetsParams) => {
-  return [`/datasets`, ...(params ? [params] : [])] as const;
-};
+export const getGetDatasetsQueryKey = (params?: GetDatasetsParams,) => {
+    return [`/datasets`, ...(params ? [params]: [])] as const;
+    }
 
-export const getGetDatasetsQueryOptions = <
-  TData = Awaited<ReturnType<typeof getDatasets>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetDatasetsParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasets>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
+    
+export const getGetDatasetsQueryOptions = <TData = Awaited<ReturnType<typeof getDatasets>>, TError = ErrorType<Error>>(params?: GetDatasetsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasets>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetDatasetsQueryKey(params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasets>>> = ({ signal }) =>
-    getDatasets(params, requestOptions, signal);
+  const queryKey =  queryOptions?.queryKey ?? getGetDatasetsQueryKey(params);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getDatasets>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+  
 
-export type GetDatasetsQueryResult = NonNullable<Awaited<ReturnType<typeof getDatasets>>>;
-export type GetDatasetsQueryError = ErrorType<Error>;
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasets>>> = ({ signal }) => getDatasets(params, requestOptions, signal);
 
-export const useGetDatasets = <
-  TData = Awaited<ReturnType<typeof getDatasets>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetDatasetsParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasets>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetDatasetsQueryOptions(params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+      
 
-  query.queryKey = queryOptions.queryKey;
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getDatasets>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetDatasetsQueryResult = NonNullable<Awaited<ReturnType<typeof getDatasets>>>
+export type GetDatasetsQueryError = ErrorType<Error>
+
+export const useGetDatasets = <TData = Awaited<ReturnType<typeof getDatasets>>, TError = ErrorType<Error>>(
+ params?: GetDatasetsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasets>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetDatasetsQueryOptions(params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const postDatasets = (
-  datasetRequest: DatasetRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<DatasetResponse>(
-    {
-      url: `/datasets`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: datasetRequest,
+    datasetRequest: DatasetRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<DatasetResponse>(
+      {url: `/datasets`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: datasetRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPostDatasetsMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postDatasets>>,
-    TError,
-    { data: DatasetRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof postDatasets>>,
-  TError,
-  { data: DatasetRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof postDatasets>>,
-    { data: DatasetRequest }
-  > = (props) => {
-    const { data } = props ?? {};
+export const getPostDatasetsMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postDatasets>>, TError,{data: DatasetRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof postDatasets>>, TError,{data: DatasetRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return postDatasets(data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PostDatasetsMutationResult = NonNullable<Awaited<ReturnType<typeof postDatasets>>>;
-export type PostDatasetsMutationBody = DatasetRequest;
-export type PostDatasetsMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postDatasets>>, {data: DatasetRequest}> = (props) => {
+          const {data} = props ?? {};
 
-export const usePostDatasets = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postDatasets>>,
-    TError,
-    { data: DatasetRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof postDatasets>>,
-  TError,
-  { data: DatasetRequest },
-  TContext
-> => {
-  const mutationOptions = getPostDatasetsMutationOptions(options);
+          return  postDatasets(data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const getDatasetsId = (
-  id: number,
-  params?: GetDatasetsIdParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostDatasetsMutationResult = NonNullable<Awaited<ReturnType<typeof postDatasets>>>
+    export type PostDatasetsMutationBody = DatasetRequest
+    export type PostDatasetsMutationError = ErrorType<Error>
+
+    export const usePostDatasets = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postDatasets>>, TError,{data: DatasetRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof postDatasets>>,
+        TError,
+        {data: DatasetRequest},
+        TContext
+      > => {
+
+      const mutationOptions = getPostDatasetsMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    export const getDatasetsId = (
+    id: number,
+    params?: GetDatasetsIdParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<DatasetResponse>({ url: `/datasets/${id}`, method: "GET", params, signal }, options);
-};
+      
+      
+      return API<DatasetResponse>(
+      {url: `/datasets/${id}`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetDatasetsIdQueryKey = (id: number, params?: GetDatasetsIdParams) => {
-  return [`/datasets/${id}`, ...(params ? [params] : [])] as const;
-};
+export const getGetDatasetsIdQueryKey = (id: number,
+    params?: GetDatasetsIdParams,) => {
+    return [`/datasets/${id}`, ...(params ? [params]: [])] as const;
+    }
 
-export const getGetDatasetsIdQueryOptions = <
-  TData = Awaited<ReturnType<typeof getDatasetsId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetDatasetsIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetsId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
+    
+export const getGetDatasetsIdQueryOptions = <TData = Awaited<ReturnType<typeof getDatasetsId>>, TError = ErrorType<Error>>(id: number,
+    params?: GetDatasetsIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetsId>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetDatasetsIdQueryKey(id, params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasetsId>>> = ({ signal }) =>
-    getDatasetsId(id, params, requestOptions, signal);
+  const queryKey =  queryOptions?.queryKey ?? getGetDatasetsIdQueryKey(id,params);
 
-  return { queryKey, queryFn, enabled: !!id, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getDatasetsId>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+  
 
-export type GetDatasetsIdQueryResult = NonNullable<Awaited<ReturnType<typeof getDatasetsId>>>;
-export type GetDatasetsIdQueryError = ErrorType<Error>;
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getDatasetsId>>> = ({ signal }) => getDatasetsId(id,params, requestOptions, signal);
 
-export const useGetDatasetsId = <
-  TData = Awaited<ReturnType<typeof getDatasetsId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetDatasetsIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetsId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetDatasetsIdQueryOptions(id, params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+      
 
-  query.queryKey = queryOptions.queryKey;
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getDatasetsId>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetDatasetsIdQueryResult = NonNullable<Awaited<ReturnType<typeof getDatasetsId>>>
+export type GetDatasetsIdQueryError = ErrorType<Error>
+
+export const useGetDatasetsId = <TData = Awaited<ReturnType<typeof getDatasetsId>>, TError = ErrorType<Error>>(
+ id: number,
+    params?: GetDatasetsIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getDatasetsId>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetDatasetsIdQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const putDatasetsId = (
-  id: number,
-  datasetRequest: DatasetRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<DatasetResponse>(
-    {
-      url: `/datasets/${id}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: datasetRequest,
+    id: number,
+    datasetRequest: DatasetRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<DatasetResponse>(
+      {url: `/datasets/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: datasetRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPutDatasetsIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putDatasetsId>>,
-    TError,
-    { id: number; data: DatasetRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof putDatasetsId>>,
-  TError,
-  { id: number; data: DatasetRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof putDatasetsId>>,
-    { id: number; data: DatasetRequest }
-  > = (props) => {
-    const { id, data } = props ?? {};
+export const getPutDatasetsIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putDatasetsId>>, TError,{id: number;data: DatasetRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof putDatasetsId>>, TError,{id: number;data: DatasetRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return putDatasetsId(id, data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PutDatasetsIdMutationResult = NonNullable<Awaited<ReturnType<typeof putDatasetsId>>>;
-export type PutDatasetsIdMutationBody = DatasetRequest;
-export type PutDatasetsIdMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof putDatasetsId>>, {id: number;data: DatasetRequest}> = (props) => {
+          const {id,data} = props ?? {};
 
-export const usePutDatasetsId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putDatasetsId>>,
-    TError,
-    { id: number; data: DatasetRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof putDatasetsId>>,
-  TError,
-  { id: number; data: DatasetRequest },
-  TContext
-> => {
-  const mutationOptions = getPutDatasetsIdMutationOptions(options);
+          return  putDatasetsId(id,data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const deleteDatasetsId = (id: number, options?: SecondParameter<typeof API>) => {
-  return API<number>({ url: `/datasets/${id}`, method: "DELETE" }, options);
-};
+        
 
-export const getDeleteDatasetsIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteDatasetsId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof deleteDatasetsId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof deleteDatasetsId>>,
-    { id: number }
-  > = (props) => {
-    const { id } = props ?? {};
+  return  { mutationFn, ...mutationOptions }}
 
-    return deleteDatasetsId(id, requestOptions);
-  };
+    export type PutDatasetsIdMutationResult = NonNullable<Awaited<ReturnType<typeof putDatasetsId>>>
+    export type PutDatasetsIdMutationBody = DatasetRequest
+    export type PutDatasetsIdMutationError = ErrorType<Error>
 
-  return { mutationFn, ...mutationOptions };
-};
+    export const usePutDatasetsId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putDatasetsId>>, TError,{id: number;data: DatasetRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof putDatasetsId>>,
+        TError,
+        {id: number;data: DatasetRequest},
+        TContext
+      > => {
 
-export type DeleteDatasetsIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof deleteDatasetsId>>
->;
+      const mutationOptions = getPutDatasetsIdMutationOptions(options);
 
-export type DeleteDatasetsIdMutationError = ErrorType<Error>;
+      return useMutation(mutationOptions);
+    }
+    export const deleteDatasetsId = (
+    id: number,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<number>(
+      {url: `/datasets/${id}`, method: 'DELETE'
+    },
+      options);
+    }
+  
 
-export const useDeleteDatasetsId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteDatasetsId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof deleteDatasetsId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const mutationOptions = getDeleteDatasetsIdMutationOptions(options);
 
-  return useMutation(mutationOptions);
-};
+export const getDeleteDatasetsIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteDatasetsId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof deleteDatasetsId>>, TError,{id: number}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteDatasetsId>>, {id: number}> = (props) => {
+          const {id} = props ?? {};
+
+          return  deleteDatasetsId(id,requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type DeleteDatasetsIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteDatasetsId>>>
+    
+    export type DeleteDatasetsIdMutationError = ErrorType<Error>
+
+    export const useDeleteDatasetsId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteDatasetsId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof deleteDatasetsId>>,
+        TError,
+        {id: number},
+        TContext
+      > => {
+
+      const mutationOptions = getDeleteDatasetsIdMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    

--- a/client/src/types/generated/ecoregion.ts
+++ b/client/src/types/generated/ecoregion.ts
@@ -4,7 +4,10 @@
  * DOCUMENTATION
  * OpenAPI spec version: 1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query'
 import type {
   MutationFunction,
   QueryFunction,
@@ -12,338 +15,290 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query'
 import type {
   EcoregionListResponse,
   EcoregionRequest,
   EcoregionResponse,
   Error,
   GetEcoregionsIdParams,
-  GetEcoregionsParams,
-} from "./strapi.schemas";
-import { API } from "../../services/api/index";
-import type { ErrorType } from "../../services/api/index";
+  GetEcoregionsParams
+} from './strapi.schemas'
+import { API } from '../../services/api/index';
+import type { ErrorType } from '../../services/api/index';
+
+
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
+
 export const getEcoregions = (
-  params?: GetEcoregionsParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+    params?: GetEcoregionsParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<EcoregionListResponse>({ url: `/ecoregions`, method: "GET", params, signal }, options);
-};
+      
+      
+      return API<EcoregionListResponse>(
+      {url: `/ecoregions`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetEcoregionsQueryKey = (params?: GetEcoregionsParams) => {
-  return [`/ecoregions`, ...(params ? [params] : [])] as const;
-};
+export const getGetEcoregionsQueryKey = (params?: GetEcoregionsParams,) => {
+    return [`/ecoregions`, ...(params ? [params]: [])] as const;
+    }
 
-export const getGetEcoregionsQueryOptions = <
-  TData = Awaited<ReturnType<typeof getEcoregions>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetEcoregionsParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregions>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
+    
+export const getGetEcoregionsQueryOptions = <TData = Awaited<ReturnType<typeof getEcoregions>>, TError = ErrorType<Error>>(params?: GetEcoregionsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregions>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetEcoregionsQueryKey(params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getEcoregions>>> = ({ signal }) =>
-    getEcoregions(params, requestOptions, signal);
+  const queryKey =  queryOptions?.queryKey ?? getGetEcoregionsQueryKey(params);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getEcoregions>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+  
 
-export type GetEcoregionsQueryResult = NonNullable<Awaited<ReturnType<typeof getEcoregions>>>;
-export type GetEcoregionsQueryError = ErrorType<Error>;
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getEcoregions>>> = ({ signal }) => getEcoregions(params, requestOptions, signal);
 
-export const useGetEcoregions = <
-  TData = Awaited<ReturnType<typeof getEcoregions>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetEcoregionsParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregions>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetEcoregionsQueryOptions(params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+      
 
-  query.queryKey = queryOptions.queryKey;
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getEcoregions>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetEcoregionsQueryResult = NonNullable<Awaited<ReturnType<typeof getEcoregions>>>
+export type GetEcoregionsQueryError = ErrorType<Error>
+
+export const useGetEcoregions = <TData = Awaited<ReturnType<typeof getEcoregions>>, TError = ErrorType<Error>>(
+ params?: GetEcoregionsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregions>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetEcoregionsQueryOptions(params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const postEcoregions = (
-  ecoregionRequest: EcoregionRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<EcoregionResponse>(
-    {
-      url: `/ecoregions`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: ecoregionRequest,
+    ecoregionRequest: EcoregionRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<EcoregionResponse>(
+      {url: `/ecoregions`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: ecoregionRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPostEcoregionsMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postEcoregions>>,
-    TError,
-    { data: EcoregionRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof postEcoregions>>,
-  TError,
-  { data: EcoregionRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof postEcoregions>>,
-    { data: EcoregionRequest }
-  > = (props) => {
-    const { data } = props ?? {};
+export const getPostEcoregionsMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postEcoregions>>, TError,{data: EcoregionRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof postEcoregions>>, TError,{data: EcoregionRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return postEcoregions(data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PostEcoregionsMutationResult = NonNullable<Awaited<ReturnType<typeof postEcoregions>>>;
-export type PostEcoregionsMutationBody = EcoregionRequest;
-export type PostEcoregionsMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postEcoregions>>, {data: EcoregionRequest}> = (props) => {
+          const {data} = props ?? {};
 
-export const usePostEcoregions = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postEcoregions>>,
-    TError,
-    { data: EcoregionRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof postEcoregions>>,
-  TError,
-  { data: EcoregionRequest },
-  TContext
-> => {
-  const mutationOptions = getPostEcoregionsMutationOptions(options);
+          return  postEcoregions(data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const getEcoregionsId = (
-  id: number,
-  params?: GetEcoregionsIdParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostEcoregionsMutationResult = NonNullable<Awaited<ReturnType<typeof postEcoregions>>>
+    export type PostEcoregionsMutationBody = EcoregionRequest
+    export type PostEcoregionsMutationError = ErrorType<Error>
+
+    export const usePostEcoregions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postEcoregions>>, TError,{data: EcoregionRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof postEcoregions>>,
+        TError,
+        {data: EcoregionRequest},
+        TContext
+      > => {
+
+      const mutationOptions = getPostEcoregionsMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    export const getEcoregionsId = (
+    id: number,
+    params?: GetEcoregionsIdParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<EcoregionResponse>(
-    { url: `/ecoregions/${id}`, method: "GET", params, signal },
-    options,
-  );
-};
+      
+      
+      return API<EcoregionResponse>(
+      {url: `/ecoregions/${id}`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetEcoregionsIdQueryKey = (id: number, params?: GetEcoregionsIdParams) => {
-  return [`/ecoregions/${id}`, ...(params ? [params] : [])] as const;
-};
+export const getGetEcoregionsIdQueryKey = (id: number,
+    params?: GetEcoregionsIdParams,) => {
+    return [`/ecoregions/${id}`, ...(params ? [params]: [])] as const;
+    }
 
-export const getGetEcoregionsIdQueryOptions = <
-  TData = Awaited<ReturnType<typeof getEcoregionsId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetEcoregionsIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregionsId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
+    
+export const getGetEcoregionsIdQueryOptions = <TData = Awaited<ReturnType<typeof getEcoregionsId>>, TError = ErrorType<Error>>(id: number,
+    params?: GetEcoregionsIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregionsId>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetEcoregionsIdQueryKey(id, params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getEcoregionsId>>> = ({ signal }) =>
-    getEcoregionsId(id, params, requestOptions, signal);
+  const queryKey =  queryOptions?.queryKey ?? getGetEcoregionsIdQueryKey(id,params);
 
-  return { queryKey, queryFn, enabled: !!id, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getEcoregionsId>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+  
 
-export type GetEcoregionsIdQueryResult = NonNullable<Awaited<ReturnType<typeof getEcoregionsId>>>;
-export type GetEcoregionsIdQueryError = ErrorType<Error>;
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getEcoregionsId>>> = ({ signal }) => getEcoregionsId(id,params, requestOptions, signal);
 
-export const useGetEcoregionsId = <
-  TData = Awaited<ReturnType<typeof getEcoregionsId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetEcoregionsIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregionsId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetEcoregionsIdQueryOptions(id, params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+      
 
-  query.queryKey = queryOptions.queryKey;
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getEcoregionsId>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetEcoregionsIdQueryResult = NonNullable<Awaited<ReturnType<typeof getEcoregionsId>>>
+export type GetEcoregionsIdQueryError = ErrorType<Error>
+
+export const useGetEcoregionsId = <TData = Awaited<ReturnType<typeof getEcoregionsId>>, TError = ErrorType<Error>>(
+ id: number,
+    params?: GetEcoregionsIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getEcoregionsId>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetEcoregionsIdQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const putEcoregionsId = (
-  id: number,
-  ecoregionRequest: EcoregionRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<EcoregionResponse>(
-    {
-      url: `/ecoregions/${id}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: ecoregionRequest,
+    id: number,
+    ecoregionRequest: EcoregionRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<EcoregionResponse>(
+      {url: `/ecoregions/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: ecoregionRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPutEcoregionsIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putEcoregionsId>>,
-    TError,
-    { id: number; data: EcoregionRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof putEcoregionsId>>,
-  TError,
-  { id: number; data: EcoregionRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof putEcoregionsId>>,
-    { id: number; data: EcoregionRequest }
-  > = (props) => {
-    const { id, data } = props ?? {};
+export const getPutEcoregionsIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putEcoregionsId>>, TError,{id: number;data: EcoregionRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof putEcoregionsId>>, TError,{id: number;data: EcoregionRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return putEcoregionsId(id, data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PutEcoregionsIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof putEcoregionsId>>
->;
-export type PutEcoregionsIdMutationBody = EcoregionRequest;
-export type PutEcoregionsIdMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof putEcoregionsId>>, {id: number;data: EcoregionRequest}> = (props) => {
+          const {id,data} = props ?? {};
 
-export const usePutEcoregionsId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putEcoregionsId>>,
-    TError,
-    { id: number; data: EcoregionRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof putEcoregionsId>>,
-  TError,
-  { id: number; data: EcoregionRequest },
-  TContext
-> => {
-  const mutationOptions = getPutEcoregionsIdMutationOptions(options);
+          return  putEcoregionsId(id,data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const deleteEcoregionsId = (id: number, options?: SecondParameter<typeof API>) => {
-  return API<number>({ url: `/ecoregions/${id}`, method: "DELETE" }, options);
-};
+        
 
-export const getDeleteEcoregionsIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteEcoregionsId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof deleteEcoregionsId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof deleteEcoregionsId>>,
-    { id: number }
-  > = (props) => {
-    const { id } = props ?? {};
+  return  { mutationFn, ...mutationOptions }}
 
-    return deleteEcoregionsId(id, requestOptions);
-  };
+    export type PutEcoregionsIdMutationResult = NonNullable<Awaited<ReturnType<typeof putEcoregionsId>>>
+    export type PutEcoregionsIdMutationBody = EcoregionRequest
+    export type PutEcoregionsIdMutationError = ErrorType<Error>
 
-  return { mutationFn, ...mutationOptions };
-};
+    export const usePutEcoregionsId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putEcoregionsId>>, TError,{id: number;data: EcoregionRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof putEcoregionsId>>,
+        TError,
+        {id: number;data: EcoregionRequest},
+        TContext
+      > => {
 
-export type DeleteEcoregionsIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof deleteEcoregionsId>>
->;
+      const mutationOptions = getPutEcoregionsIdMutationOptions(options);
 
-export type DeleteEcoregionsIdMutationError = ErrorType<Error>;
+      return useMutation(mutationOptions);
+    }
+    export const deleteEcoregionsId = (
+    id: number,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<number>(
+      {url: `/ecoregions/${id}`, method: 'DELETE'
+    },
+      options);
+    }
+  
 
-export const useDeleteEcoregionsId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteEcoregionsId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof deleteEcoregionsId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const mutationOptions = getDeleteEcoregionsIdMutationOptions(options);
 
-  return useMutation(mutationOptions);
-};
+export const getDeleteEcoregionsIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteEcoregionsId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof deleteEcoregionsId>>, TError,{id: number}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteEcoregionsId>>, {id: number}> = (props) => {
+          const {id} = props ?? {};
+
+          return  deleteEcoregionsId(id,requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type DeleteEcoregionsIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteEcoregionsId>>>
+    
+    export type DeleteEcoregionsIdMutationError = ErrorType<Error>
+
+    export const useDeleteEcoregionsId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteEcoregionsId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof deleteEcoregionsId>>,
+        TError,
+        {id: number},
+        TContext
+      > => {
+
+      const mutationOptions = getDeleteEcoregionsIdMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    

--- a/client/src/types/generated/layer.ts
+++ b/client/src/types/generated/layer.ts
@@ -4,7 +4,10 @@
  * DOCUMENTATION
  * OpenAPI spec version: 1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query'
 import type {
   MutationFunction,
   QueryFunction,
@@ -12,327 +15,290 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query'
 import type {
   Error,
   GetLayersIdParams,
   GetLayersParams,
   LayerListResponse,
   LayerRequest,
-  LayerResponse,
-} from "./strapi.schemas";
-import { API } from "../../services/api/index";
-import type { ErrorType } from "../../services/api/index";
+  LayerResponse
+} from './strapi.schemas'
+import { API } from '../../services/api/index';
+import type { ErrorType } from '../../services/api/index';
+
+
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
+
 export const getLayers = (
-  params?: GetLayersParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+    params?: GetLayersParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<LayerListResponse>({ url: `/layers`, method: "GET", params, signal }, options);
-};
-
-export const getGetLayersQueryKey = (params?: GetLayersParams) => {
-  return [`/layers`, ...(params ? [params] : [])] as const;
-};
-
-export const getGetLayersQueryOptions = <
-  TData = Awaited<ReturnType<typeof getLayers>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetLayersParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayers>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
-
-  const queryKey = queryOptions?.queryKey ?? getGetLayersQueryKey(params);
-
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getLayers>>> = ({ signal }) =>
-    getLayers(params, requestOptions, signal);
-
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getLayers>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
-
-export type GetLayersQueryResult = NonNullable<Awaited<ReturnType<typeof getLayers>>>;
-export type GetLayersQueryError = ErrorType<Error>;
-
-export const useGetLayers = <
-  TData = Awaited<ReturnType<typeof getLayers>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetLayersParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayers>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetLayersQueryOptions(params, options);
-
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
-
-  query.queryKey = queryOptions.queryKey;
-
-  return query;
-};
-
-export const postLayers = (layerRequest: LayerRequest, options?: SecondParameter<typeof API>) => {
-  return API<LayerResponse>(
-    {
-      url: `/layers`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: layerRequest,
+      
+      
+      return API<LayerListResponse>(
+      {url: `/layers`, method: 'GET',
+        params, signal
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPostLayersMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postLayers>>,
-    TError,
-    { data: LayerRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof postLayers>>,
-  TError,
-  { data: LayerRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
+export const getGetLayersQueryKey = (params?: GetLayersParams,) => {
+    return [`/layers`, ...(params ? [params]: [])] as const;
+    }
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof postLayers>>,
-    { data: LayerRequest }
-  > = (props) => {
-    const { data } = props ?? {};
-
-    return postLayers(data, requestOptions);
-  };
-
-  return { mutationFn, ...mutationOptions };
-};
-
-export type PostLayersMutationResult = NonNullable<Awaited<ReturnType<typeof postLayers>>>;
-export type PostLayersMutationBody = LayerRequest;
-export type PostLayersMutationError = ErrorType<Error>;
-
-export const usePostLayers = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postLayers>>,
-    TError,
-    { data: LayerRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof postLayers>>,
-  TError,
-  { data: LayerRequest },
-  TContext
-> => {
-  const mutationOptions = getPostLayersMutationOptions(options);
-
-  return useMutation(mutationOptions);
-};
-export const getLayersId = (
-  id: number,
-  params?: GetLayersIdParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+    
+export const getGetLayersQueryOptions = <TData = Awaited<ReturnType<typeof getLayers>>, TError = ErrorType<Error>>(params?: GetLayersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayers>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  return API<LayerResponse>({ url: `/layers/${id}`, method: "GET", params, signal }, options);
-};
 
-export const getGetLayersIdQueryKey = (id: number, params?: GetLayersIdParams) => {
-  return [`/layers/${id}`, ...(params ? [params] : [])] as const;
-};
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-export const getGetLayersIdQueryOptions = <
-  TData = Awaited<ReturnType<typeof getLayersId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetLayersIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayersId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
+  const queryKey =  queryOptions?.queryKey ?? getGetLayersQueryKey(params);
 
-  const queryKey = queryOptions?.queryKey ?? getGetLayersIdQueryKey(id, params);
+  
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getLayersId>>> = ({ signal }) =>
-    getLayersId(id, params, requestOptions, signal);
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getLayers>>> = ({ signal }) => getLayers(params, requestOptions, signal);
 
-  return { queryKey, queryFn, enabled: !!id, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getLayersId>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+      
 
-export type GetLayersIdQueryResult = NonNullable<Awaited<ReturnType<typeof getLayersId>>>;
-export type GetLayersIdQueryError = ErrorType<Error>;
+      
 
-export const useGetLayersId = <
-  TData = Awaited<ReturnType<typeof getLayersId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetLayersIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayersId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetLayersIdQueryOptions(id, params, options);
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getLayers>>, TError, TData> & { queryKey: QueryKey }
+}
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+export type GetLayersQueryResult = NonNullable<Awaited<ReturnType<typeof getLayers>>>
+export type GetLayersQueryError = ErrorType<Error>
 
-  query.queryKey = queryOptions.queryKey;
+export const useGetLayers = <TData = Awaited<ReturnType<typeof getLayers>>, TError = ErrorType<Error>>(
+ params?: GetLayersParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayers>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetLayersQueryOptions(params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
+
+export const postLayers = (
+    layerRequest: LayerRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<LayerResponse>(
+      {url: `/layers`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: layerRequest
+    },
+      options);
+    }
+  
+
+
+export const getPostLayersMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postLayers>>, TError,{data: LayerRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof postLayers>>, TError,{data: LayerRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postLayers>>, {data: LayerRequest}> = (props) => {
+          const {data} = props ?? {};
+
+          return  postLayers(data,requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostLayersMutationResult = NonNullable<Awaited<ReturnType<typeof postLayers>>>
+    export type PostLayersMutationBody = LayerRequest
+    export type PostLayersMutationError = ErrorType<Error>
+
+    export const usePostLayers = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postLayers>>, TError,{data: LayerRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof postLayers>>,
+        TError,
+        {data: LayerRequest},
+        TContext
+      > => {
+
+      const mutationOptions = getPostLayersMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    export const getLayersId = (
+    id: number,
+    params?: GetLayersIdParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
+) => {
+      
+      
+      return API<LayerResponse>(
+      {url: `/layers/${id}`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
+
+export const getGetLayersIdQueryKey = (id: number,
+    params?: GetLayersIdParams,) => {
+    return [`/layers/${id}`, ...(params ? [params]: [])] as const;
+    }
+
+    
+export const getGetLayersIdQueryOptions = <TData = Awaited<ReturnType<typeof getLayersId>>, TError = ErrorType<Error>>(id: number,
+    params?: GetLayersIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayersId>>, TError, TData>>, request?: SecondParameter<typeof API>}
+) => {
+
+const {query: queryOptions, request: requestOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getGetLayersIdQueryKey(id,params);
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getLayersId>>> = ({ signal }) => getLayersId(id,params, requestOptions, signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getLayersId>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetLayersIdQueryResult = NonNullable<Awaited<ReturnType<typeof getLayersId>>>
+export type GetLayersIdQueryError = ErrorType<Error>
+
+export const useGetLayersId = <TData = Awaited<ReturnType<typeof getLayersId>>, TError = ErrorType<Error>>(
+ id: number,
+    params?: GetLayersIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getLayersId>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetLayersIdQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
 
 export const putLayersId = (
-  id: number,
-  layerRequest: LayerRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<LayerResponse>(
-    {
-      url: `/layers/${id}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: layerRequest,
+    id: number,
+    layerRequest: LayerRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<LayerResponse>(
+      {url: `/layers/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: layerRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPutLayersIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putLayersId>>,
-    TError,
-    { id: number; data: LayerRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof putLayersId>>,
-  TError,
-  { id: number; data: LayerRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof putLayersId>>,
-    { id: number; data: LayerRequest }
-  > = (props) => {
-    const { id, data } = props ?? {};
+export const getPutLayersIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putLayersId>>, TError,{id: number;data: LayerRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof putLayersId>>, TError,{id: number;data: LayerRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return putLayersId(id, data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PutLayersIdMutationResult = NonNullable<Awaited<ReturnType<typeof putLayersId>>>;
-export type PutLayersIdMutationBody = LayerRequest;
-export type PutLayersIdMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof putLayersId>>, {id: number;data: LayerRequest}> = (props) => {
+          const {id,data} = props ?? {};
 
-export const usePutLayersId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putLayersId>>,
-    TError,
-    { id: number; data: LayerRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof putLayersId>>,
-  TError,
-  { id: number; data: LayerRequest },
-  TContext
-> => {
-  const mutationOptions = getPutLayersIdMutationOptions(options);
+          return  putLayersId(id,data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const deleteLayersId = (id: number, options?: SecondParameter<typeof API>) => {
-  return API<number>({ url: `/layers/${id}`, method: "DELETE" }, options);
-};
+        
 
-export const getDeleteLayersIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteLayersId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof deleteLayersId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteLayersId>>, { id: number }> = (
-    props,
-  ) => {
-    const { id } = props ?? {};
+  return  { mutationFn, ...mutationOptions }}
 
-    return deleteLayersId(id, requestOptions);
-  };
+    export type PutLayersIdMutationResult = NonNullable<Awaited<ReturnType<typeof putLayersId>>>
+    export type PutLayersIdMutationBody = LayerRequest
+    export type PutLayersIdMutationError = ErrorType<Error>
 
-  return { mutationFn, ...mutationOptions };
-};
+    export const usePutLayersId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putLayersId>>, TError,{id: number;data: LayerRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof putLayersId>>,
+        TError,
+        {id: number;data: LayerRequest},
+        TContext
+      > => {
 
-export type DeleteLayersIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteLayersId>>>;
+      const mutationOptions = getPutLayersIdMutationOptions(options);
 
-export type DeleteLayersIdMutationError = ErrorType<Error>;
+      return useMutation(mutationOptions);
+    }
+    export const deleteLayersId = (
+    id: number,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<number>(
+      {url: `/layers/${id}`, method: 'DELETE'
+    },
+      options);
+    }
+  
 
-export const useDeleteLayersId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteLayersId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof deleteLayersId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const mutationOptions = getDeleteLayersIdMutationOptions(options);
 
-  return useMutation(mutationOptions);
-};
+export const getDeleteLayersIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteLayersId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof deleteLayersId>>, TError,{id: number}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteLayersId>>, {id: number}> = (props) => {
+          const {id} = props ?? {};
+
+          return  deleteLayersId(id,requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type DeleteLayersIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteLayersId>>>
+    
+    export type DeleteLayersIdMutationError = ErrorType<Error>
+
+    export const useDeleteLayersId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteLayersId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof deleteLayersId>>,
+        TError,
+        {id: number},
+        TContext
+      > => {
+
+      const mutationOptions = getDeleteLayersIdMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    

--- a/client/src/types/generated/rangeland.ts
+++ b/client/src/types/generated/rangeland.ts
@@ -4,7 +4,10 @@
  * DOCUMENTATION
  * OpenAPI spec version: 1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query'
 import type {
   MutationFunction,
   QueryFunction,
@@ -12,338 +15,290 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query'
 import type {
   Error,
   GetRangelandsIdParams,
   GetRangelandsParams,
   RangelandListResponse,
   RangelandRequest,
-  RangelandResponse,
-} from "./strapi.schemas";
-import { API } from "../../services/api/index";
-import type { ErrorType } from "../../services/api/index";
+  RangelandResponse
+} from './strapi.schemas'
+import { API } from '../../services/api/index';
+import type { ErrorType } from '../../services/api/index';
+
+
 
 type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1];
 
+
 export const getRangelands = (
-  params?: GetRangelandsParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+    params?: GetRangelandsParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<RangelandListResponse>({ url: `/rangelands`, method: "GET", params, signal }, options);
-};
+      
+      
+      return API<RangelandListResponse>(
+      {url: `/rangelands`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetRangelandsQueryKey = (params?: GetRangelandsParams) => {
-  return [`/rangelands`, ...(params ? [params] : [])] as const;
-};
+export const getGetRangelandsQueryKey = (params?: GetRangelandsParams,) => {
+    return [`/rangelands`, ...(params ? [params]: [])] as const;
+    }
 
-export const getGetRangelandsQueryOptions = <
-  TData = Awaited<ReturnType<typeof getRangelands>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetRangelandsParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelands>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
+    
+export const getGetRangelandsQueryOptions = <TData = Awaited<ReturnType<typeof getRangelands>>, TError = ErrorType<Error>>(params?: GetRangelandsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelands>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetRangelandsQueryKey(params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getRangelands>>> = ({ signal }) =>
-    getRangelands(params, requestOptions, signal);
+  const queryKey =  queryOptions?.queryKey ?? getGetRangelandsQueryKey(params);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getRangelands>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+  
 
-export type GetRangelandsQueryResult = NonNullable<Awaited<ReturnType<typeof getRangelands>>>;
-export type GetRangelandsQueryError = ErrorType<Error>;
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getRangelands>>> = ({ signal }) => getRangelands(params, requestOptions, signal);
 
-export const useGetRangelands = <
-  TData = Awaited<ReturnType<typeof getRangelands>>,
-  TError = ErrorType<Error>,
->(
-  params?: GetRangelandsParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelands>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetRangelandsQueryOptions(params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+      
 
-  query.queryKey = queryOptions.queryKey;
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getRangelands>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetRangelandsQueryResult = NonNullable<Awaited<ReturnType<typeof getRangelands>>>
+export type GetRangelandsQueryError = ErrorType<Error>
+
+export const useGetRangelands = <TData = Awaited<ReturnType<typeof getRangelands>>, TError = ErrorType<Error>>(
+ params?: GetRangelandsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelands>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetRangelandsQueryOptions(params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const postRangelands = (
-  rangelandRequest: RangelandRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<RangelandResponse>(
-    {
-      url: `/rangelands`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      data: rangelandRequest,
+    rangelandRequest: RangelandRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<RangelandResponse>(
+      {url: `/rangelands`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: rangelandRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPostRangelandsMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postRangelands>>,
-    TError,
-    { data: RangelandRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof postRangelands>>,
-  TError,
-  { data: RangelandRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof postRangelands>>,
-    { data: RangelandRequest }
-  > = (props) => {
-    const { data } = props ?? {};
+export const getPostRangelandsMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postRangelands>>, TError,{data: RangelandRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof postRangelands>>, TError,{data: RangelandRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return postRangelands(data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PostRangelandsMutationResult = NonNullable<Awaited<ReturnType<typeof postRangelands>>>;
-export type PostRangelandsMutationBody = RangelandRequest;
-export type PostRangelandsMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postRangelands>>, {data: RangelandRequest}> = (props) => {
+          const {data} = props ?? {};
 
-export const usePostRangelands = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof postRangelands>>,
-    TError,
-    { data: RangelandRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof postRangelands>>,
-  TError,
-  { data: RangelandRequest },
-  TContext
-> => {
-  const mutationOptions = getPostRangelandsMutationOptions(options);
+          return  postRangelands(data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const getRangelandsId = (
-  id: number,
-  params?: GetRangelandsIdParams,
-  options?: SecondParameter<typeof API>,
-  signal?: AbortSignal,
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostRangelandsMutationResult = NonNullable<Awaited<ReturnType<typeof postRangelands>>>
+    export type PostRangelandsMutationBody = RangelandRequest
+    export type PostRangelandsMutationError = ErrorType<Error>
+
+    export const usePostRangelands = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postRangelands>>, TError,{data: RangelandRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof postRangelands>>,
+        TError,
+        {data: RangelandRequest},
+        TContext
+      > => {
+
+      const mutationOptions = getPostRangelandsMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    export const getRangelandsId = (
+    id: number,
+    params?: GetRangelandsIdParams,
+ options?: SecondParameter<typeof API>,signal?: AbortSignal
 ) => {
-  return API<RangelandResponse>(
-    { url: `/rangelands/${id}`, method: "GET", params, signal },
-    options,
-  );
-};
+      
+      
+      return API<RangelandResponse>(
+      {url: `/rangelands/${id}`, method: 'GET',
+        params, signal
+    },
+      options);
+    }
+  
 
-export const getGetRangelandsIdQueryKey = (id: number, params?: GetRangelandsIdParams) => {
-  return [`/rangelands/${id}`, ...(params ? [params] : [])] as const;
-};
+export const getGetRangelandsIdQueryKey = (id: number,
+    params?: GetRangelandsIdParams,) => {
+    return [`/rangelands/${id}`, ...(params ? [params]: [])] as const;
+    }
 
-export const getGetRangelandsIdQueryOptions = <
-  TData = Awaited<ReturnType<typeof getRangelandsId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetRangelandsIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelandsId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
+    
+export const getGetRangelandsIdQueryOptions = <TData = Awaited<ReturnType<typeof getRangelandsId>>, TError = ErrorType<Error>>(id: number,
+    params?: GetRangelandsIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelandsId>>, TError, TData>>, request?: SecondParameter<typeof API>}
 ) => {
-  const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetRangelandsIdQueryKey(id, params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof getRangelandsId>>> = ({ signal }) =>
-    getRangelandsId(id, params, requestOptions, signal);
+  const queryKey =  queryOptions?.queryKey ?? getGetRangelandsIdQueryKey(id,params);
 
-  return { queryKey, queryFn, enabled: !!id, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof getRangelandsId>>,
-    TError,
-    TData
-  > & { queryKey: QueryKey };
-};
+  
 
-export type GetRangelandsIdQueryResult = NonNullable<Awaited<ReturnType<typeof getRangelandsId>>>;
-export type GetRangelandsIdQueryError = ErrorType<Error>;
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getRangelandsId>>> = ({ signal }) => getRangelandsId(id,params, requestOptions, signal);
 
-export const useGetRangelandsId = <
-  TData = Awaited<ReturnType<typeof getRangelandsId>>,
-  TError = ErrorType<Error>,
->(
-  id: number,
-  params?: GetRangelandsIdParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelandsId>>, TError, TData>>;
-    request?: SecondParameter<typeof API>;
-  },
-): UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
-  const queryOptions = getGetRangelandsIdQueryOptions(id, params, options);
+      
 
-  const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
+      
 
-  query.queryKey = queryOptions.queryKey;
+   return  { queryKey, queryFn, enabled: !!(id), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getRangelandsId>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type GetRangelandsIdQueryResult = NonNullable<Awaited<ReturnType<typeof getRangelandsId>>>
+export type GetRangelandsIdQueryError = ErrorType<Error>
+
+export const useGetRangelandsId = <TData = Awaited<ReturnType<typeof getRangelandsId>>, TError = ErrorType<Error>>(
+ id: number,
+    params?: GetRangelandsIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getRangelandsId>>, TError, TData>>, request?: SecondParameter<typeof API>}
+
+  ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
+
+  const queryOptions = getGetRangelandsIdQueryOptions(id,params,options)
+
+  const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
 
   return query;
-};
+}
+
+
 
 export const putRangelandsId = (
-  id: number,
-  rangelandRequest: RangelandRequest,
-  options?: SecondParameter<typeof API>,
-) => {
-  return API<RangelandResponse>(
-    {
-      url: `/rangelands/${id}`,
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      data: rangelandRequest,
+    id: number,
+    rangelandRequest: RangelandRequest,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<RangelandResponse>(
+      {url: `/rangelands/${id}`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: rangelandRequest
     },
-    options,
-  );
-};
+      options);
+    }
+  
 
-export const getPutRangelandsIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putRangelandsId>>,
-    TError,
-    { id: number; data: RangelandRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof putRangelandsId>>,
-  TError,
-  { id: number; data: RangelandRequest },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof putRangelandsId>>,
-    { id: number; data: RangelandRequest }
-  > = (props) => {
-    const { id, data } = props ?? {};
+export const getPutRangelandsIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putRangelandsId>>, TError,{id: number;data: RangelandRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof putRangelandsId>>, TError,{id: number;data: RangelandRequest}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
 
-    return putRangelandsId(id, data, requestOptions);
-  };
+      
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type PutRangelandsIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof putRangelandsId>>
->;
-export type PutRangelandsIdMutationBody = RangelandRequest;
-export type PutRangelandsIdMutationError = ErrorType<Error>;
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof putRangelandsId>>, {id: number;data: RangelandRequest}> = (props) => {
+          const {id,data} = props ?? {};
 
-export const usePutRangelandsId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof putRangelandsId>>,
-    TError,
-    { id: number; data: RangelandRequest },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof putRangelandsId>>,
-  TError,
-  { id: number; data: RangelandRequest },
-  TContext
-> => {
-  const mutationOptions = getPutRangelandsIdMutationOptions(options);
+          return  putRangelandsId(id,data,requestOptions)
+        }
 
-  return useMutation(mutationOptions);
-};
-export const deleteRangelandsId = (id: number, options?: SecondParameter<typeof API>) => {
-  return API<number>({ url: `/rangelands/${id}`, method: "DELETE" }, options);
-};
+        
 
-export const getDeleteRangelandsIdMutationOptions = <
-  TError = ErrorType<Error>,
-  TContext = unknown,
->(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteRangelandsId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationOptions<
-  Awaited<ReturnType<typeof deleteRangelandsId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof deleteRangelandsId>>,
-    { id: number }
-  > = (props) => {
-    const { id } = props ?? {};
+  return  { mutationFn, ...mutationOptions }}
 
-    return deleteRangelandsId(id, requestOptions);
-  };
+    export type PutRangelandsIdMutationResult = NonNullable<Awaited<ReturnType<typeof putRangelandsId>>>
+    export type PutRangelandsIdMutationBody = RangelandRequest
+    export type PutRangelandsIdMutationError = ErrorType<Error>
 
-  return { mutationFn, ...mutationOptions };
-};
+    export const usePutRangelandsId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof putRangelandsId>>, TError,{id: number;data: RangelandRequest}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof putRangelandsId>>,
+        TError,
+        {id: number;data: RangelandRequest},
+        TContext
+      > => {
 
-export type DeleteRangelandsIdMutationResult = NonNullable<
-  Awaited<ReturnType<typeof deleteRangelandsId>>
->;
+      const mutationOptions = getPutRangelandsIdMutationOptions(options);
 
-export type DeleteRangelandsIdMutationError = ErrorType<Error>;
+      return useMutation(mutationOptions);
+    }
+    export const deleteRangelandsId = (
+    id: number,
+ options?: SecondParameter<typeof API>,) => {
+      
+      
+      return API<number>(
+      {url: `/rangelands/${id}`, method: 'DELETE'
+    },
+      options);
+    }
+  
 
-export const useDeleteRangelandsId = <TError = ErrorType<Error>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<
-    Awaited<ReturnType<typeof deleteRangelandsId>>,
-    TError,
-    { id: number },
-    TContext
-  >;
-  request?: SecondParameter<typeof API>;
-}): UseMutationResult<
-  Awaited<ReturnType<typeof deleteRangelandsId>>,
-  TError,
-  { id: number },
-  TContext
-> => {
-  const mutationOptions = getDeleteRangelandsIdMutationOptions(options);
 
-  return useMutation(mutationOptions);
-};
+export const getDeleteRangelandsIdMutationOptions = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteRangelandsId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationOptions<Awaited<ReturnType<typeof deleteRangelandsId>>, TError,{id: number}, TContext> => {
+const {mutation: mutationOptions, request: requestOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteRangelandsId>>, {id: number}> = (props) => {
+          const {id} = props ?? {};
+
+          return  deleteRangelandsId(id,requestOptions)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type DeleteRangelandsIdMutationResult = NonNullable<Awaited<ReturnType<typeof deleteRangelandsId>>>
+    
+    export type DeleteRangelandsIdMutationError = ErrorType<Error>
+
+    export const useDeleteRangelandsId = <TError = ErrorType<Error>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteRangelandsId>>, TError,{id: number}, TContext>, request?: SecondParameter<typeof API>}
+): UseMutationResult<
+        Awaited<ReturnType<typeof deleteRangelandsId>>,
+        TError,
+        {id: number},
+        TContext
+      > => {
+
+      const mutationOptions = getDeleteRangelandsIdMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    

--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -7,291 +7,285 @@
 export type GetRangelandsIdPopulateOneOf = { [key: string]: any };
 
 export type GetRangelandsIdParams = {
-  /**
-   * Relations to return
-   */
-  populate?: string | GetRangelandsIdPopulateOneOf;
+/**
+ * Relations to return
+ */
+populate?: string | GetRangelandsIdPopulateOneOf;
 };
 
 export type GetRangelandsPopulateOneOf = { [key: string]: any };
 
 export type GetRangelandsParams = {
-  /**
-   * Sort by attributes ascending (asc) or descending (desc)
-   */
-  sort?: string;
-  /**
-   * Return page/pageSize (default: true)
-   */
-  "pagination[withCount]"?: boolean;
-  /**
-   * Page number (default: 0)
-   */
-  "pagination[page]"?: number;
-  /**
-   * Page size (default: 25)
-   */
-  "pagination[pageSize]"?: number;
-  /**
-   * Offset value (default: 0)
-   */
-  "pagination[start]"?: number;
-  /**
-   * Number of entities to return (default: 25)
-   */
-  "pagination[limit]"?: number;
-  /**
-   * Fields to return (ex: ['title','author','test'])
-   */
-  fields?: string[];
-  /**
-   * Relations to return
-   */
-  populate?: string | GetRangelandsPopulateOneOf;
-  /**
-   * Filters to apply
-   */
-  filters?: { [key: string]: any };
-  /**
-   * Locale to apply
-   */
-  locale?: string;
+/**
+ * Sort by attributes ascending (asc) or descending (desc)
+ */
+sort?: string;
+/**
+ * Return page/pageSize (default: true)
+ */
+'pagination[withCount]'?: boolean;
+/**
+ * Page number (default: 0)
+ */
+'pagination[page]'?: number;
+/**
+ * Page size (default: 25)
+ */
+'pagination[pageSize]'?: number;
+/**
+ * Offset value (default: 0)
+ */
+'pagination[start]'?: number;
+/**
+ * Number of entities to return (default: 25)
+ */
+'pagination[limit]'?: number;
+/**
+ * Fields to return (ex: ['title','author','test'])
+ */
+fields?: string[];
+/**
+ * Relations to return
+ */
+populate?: string | GetRangelandsPopulateOneOf;
+/**
+ * Filters to apply
+ */
+filters?: { [key: string]: any };
+/**
+ * Locale to apply
+ */
+locale?: string;
 };
 
 export type GetLayersIdPopulateOneOf = { [key: string]: any };
 
 export type GetLayersIdParams = {
-  /**
-   * Relations to return
-   */
-  populate?: string | GetLayersIdPopulateOneOf;
+/**
+ * Relations to return
+ */
+populate?: string | GetLayersIdPopulateOneOf;
 };
 
 export type GetLayersPopulateOneOf = { [key: string]: any };
 
 export type GetLayersParams = {
-  /**
-   * Sort by attributes ascending (asc) or descending (desc)
-   */
-  sort?: string;
-  /**
-   * Return page/pageSize (default: true)
-   */
-  "pagination[withCount]"?: boolean;
-  /**
-   * Page number (default: 0)
-   */
-  "pagination[page]"?: number;
-  /**
-   * Page size (default: 25)
-   */
-  "pagination[pageSize]"?: number;
-  /**
-   * Offset value (default: 0)
-   */
-  "pagination[start]"?: number;
-  /**
-   * Number of entities to return (default: 25)
-   */
-  "pagination[limit]"?: number;
-  /**
-   * Fields to return (ex: ['title','author','test'])
-   */
-  fields?: string[];
-  /**
-   * Relations to return
-   */
-  populate?: string | GetLayersPopulateOneOf;
-  /**
-   * Filters to apply
-   */
-  filters?: { [key: string]: any };
-  /**
-   * Locale to apply
-   */
-  locale?: string;
+/**
+ * Sort by attributes ascending (asc) or descending (desc)
+ */
+sort?: string;
+/**
+ * Return page/pageSize (default: true)
+ */
+'pagination[withCount]'?: boolean;
+/**
+ * Page number (default: 0)
+ */
+'pagination[page]'?: number;
+/**
+ * Page size (default: 25)
+ */
+'pagination[pageSize]'?: number;
+/**
+ * Offset value (default: 0)
+ */
+'pagination[start]'?: number;
+/**
+ * Number of entities to return (default: 25)
+ */
+'pagination[limit]'?: number;
+/**
+ * Fields to return (ex: ['title','author','test'])
+ */
+fields?: string[];
+/**
+ * Relations to return
+ */
+populate?: string | GetLayersPopulateOneOf;
+/**
+ * Filters to apply
+ */
+filters?: { [key: string]: any };
+/**
+ * Locale to apply
+ */
+locale?: string;
 };
 
 export type GetEcoregionsIdPopulateOneOf = { [key: string]: any };
 
 export type GetEcoregionsIdParams = {
-  /**
-   * Relations to return
-   */
-  populate?: string | GetEcoregionsIdPopulateOneOf;
+/**
+ * Relations to return
+ */
+populate?: string | GetEcoregionsIdPopulateOneOf;
 };
 
 export type GetEcoregionsPopulateOneOf = { [key: string]: any };
 
 export type GetEcoregionsParams = {
-  /**
-   * Sort by attributes ascending (asc) or descending (desc)
-   */
-  sort?: string;
-  /**
-   * Return page/pageSize (default: true)
-   */
-  "pagination[withCount]"?: boolean;
-  /**
-   * Page number (default: 0)
-   */
-  "pagination[page]"?: number;
-  /**
-   * Page size (default: 25)
-   */
-  "pagination[pageSize]"?: number;
-  /**
-   * Offset value (default: 0)
-   */
-  "pagination[start]"?: number;
-  /**
-   * Number of entities to return (default: 25)
-   */
-  "pagination[limit]"?: number;
-  /**
-   * Fields to return (ex: ['title','author','test'])
-   */
-  fields?: string[];
-  /**
-   * Relations to return
-   */
-  populate?: string | GetEcoregionsPopulateOneOf;
-  /**
-   * Filters to apply
-   */
-  filters?: { [key: string]: any };
-  /**
-   * Locale to apply
-   */
-  locale?: string;
+/**
+ * Sort by attributes ascending (asc) or descending (desc)
+ */
+sort?: string;
+/**
+ * Return page/pageSize (default: true)
+ */
+'pagination[withCount]'?: boolean;
+/**
+ * Page number (default: 0)
+ */
+'pagination[page]'?: number;
+/**
+ * Page size (default: 25)
+ */
+'pagination[pageSize]'?: number;
+/**
+ * Offset value (default: 0)
+ */
+'pagination[start]'?: number;
+/**
+ * Number of entities to return (default: 25)
+ */
+'pagination[limit]'?: number;
+/**
+ * Fields to return (ex: ['title','author','test'])
+ */
+fields?: string[];
+/**
+ * Relations to return
+ */
+populate?: string | GetEcoregionsPopulateOneOf;
+/**
+ * Filters to apply
+ */
+filters?: { [key: string]: any };
+/**
+ * Locale to apply
+ */
+locale?: string;
 };
 
 export type GetDatasetCategoriesIdPopulateOneOf = { [key: string]: any };
 
 export type GetDatasetCategoriesIdParams = {
-  /**
-   * Relations to return
-   */
-  populate?: string | GetDatasetCategoriesIdPopulateOneOf;
+/**
+ * Relations to return
+ */
+populate?: string | GetDatasetCategoriesIdPopulateOneOf;
 };
 
 export type GetDatasetCategoriesPopulateOneOf = { [key: string]: any };
 
 export type GetDatasetCategoriesParams = {
-  /**
-   * Sort by attributes ascending (asc) or descending (desc)
-   */
-  sort?: string;
-  /**
-   * Return page/pageSize (default: true)
-   */
-  "pagination[withCount]"?: boolean;
-  /**
-   * Page number (default: 0)
-   */
-  "pagination[page]"?: number;
-  /**
-   * Page size (default: 25)
-   */
-  "pagination[pageSize]"?: number;
-  /**
-   * Offset value (default: 0)
-   */
-  "pagination[start]"?: number;
-  /**
-   * Number of entities to return (default: 25)
-   */
-  "pagination[limit]"?: number;
-  /**
-   * Fields to return (ex: ['title','author','test'])
-   */
-  fields?: string[];
-  /**
-   * Relations to return
-   */
-  populate?: string | GetDatasetCategoriesPopulateOneOf;
-  /**
-   * Filters to apply
-   */
-  filters?: { [key: string]: any };
-  /**
-   * Locale to apply
-   */
-  locale?: string;
+/**
+ * Sort by attributes ascending (asc) or descending (desc)
+ */
+sort?: string;
+/**
+ * Return page/pageSize (default: true)
+ */
+'pagination[withCount]'?: boolean;
+/**
+ * Page number (default: 0)
+ */
+'pagination[page]'?: number;
+/**
+ * Page size (default: 25)
+ */
+'pagination[pageSize]'?: number;
+/**
+ * Offset value (default: 0)
+ */
+'pagination[start]'?: number;
+/**
+ * Number of entities to return (default: 25)
+ */
+'pagination[limit]'?: number;
+/**
+ * Fields to return (ex: ['title','author','test'])
+ */
+fields?: string[];
+/**
+ * Relations to return
+ */
+populate?: string | GetDatasetCategoriesPopulateOneOf;
+/**
+ * Filters to apply
+ */
+filters?: { [key: string]: any };
+/**
+ * Locale to apply
+ */
+locale?: string;
 };
 
 export type GetDatasetsIdPopulateOneOf = { [key: string]: any };
 
 export type GetDatasetsIdParams = {
-  /**
-   * Relations to return
-   */
-  populate?: string | GetDatasetsIdPopulateOneOf;
+/**
+ * Relations to return
+ */
+populate?: string | GetDatasetsIdPopulateOneOf;
 };
 
 export type GetDatasetsPopulateOneOf = { [key: string]: any };
 
 export type GetDatasetsParams = {
-  /**
-   * Sort by attributes ascending (asc) or descending (desc)
-   */
-  sort?: string;
-  /**
-   * Return page/pageSize (default: true)
-   */
-  "pagination[withCount]"?: boolean;
-  /**
-   * Page number (default: 0)
-   */
-  "pagination[page]"?: number;
-  /**
-   * Page size (default: 25)
-   */
-  "pagination[pageSize]"?: number;
-  /**
-   * Offset value (default: 0)
-   */
-  "pagination[start]"?: number;
-  /**
-   * Number of entities to return (default: 25)
-   */
-  "pagination[limit]"?: number;
-  /**
-   * Fields to return (ex: ['title','author','test'])
-   */
-  fields?: string[];
-  /**
-   * Relations to return
-   */
-  populate?: string | GetDatasetsPopulateOneOf;
-  /**
-   * Filters to apply
-   */
-  filters?: { [key: string]: any };
-  /**
-   * Locale to apply
-   */
-  locale?: string;
+/**
+ * Sort by attributes ascending (asc) or descending (desc)
+ */
+sort?: string;
+/**
+ * Return page/pageSize (default: true)
+ */
+'pagination[withCount]'?: boolean;
+/**
+ * Page number (default: 0)
+ */
+'pagination[page]'?: number;
+/**
+ * Page size (default: 25)
+ */
+'pagination[pageSize]'?: number;
+/**
+ * Offset value (default: 0)
+ */
+'pagination[start]'?: number;
+/**
+ * Number of entities to return (default: 25)
+ */
+'pagination[limit]'?: number;
+/**
+ * Fields to return (ex: ['title','author','test'])
+ */
+fields?: string[];
+/**
+ * Relations to return
+ */
+populate?: string | GetDatasetsPopulateOneOf;
+/**
+ * Filters to apply
+ */
+filters?: { [key: string]: any };
+/**
+ * Locale to apply
+ */
+locale?: string;
 };
 
 /**
  * every controller of the api
  */
-export type UsersPermissionsPermissionsTreeControllers = {
-  [key: string]: {
-    [key: string]: {
-      enabled?: boolean;
-      policy?: string;
-    };
-  };
-};
+export type UsersPermissionsPermissionsTreeControllers = {[key: string]: {[key: string]: {
+  enabled?: boolean;
+  policy?: string;
+}}};
 
-export interface UsersPermissionsPermissionsTree {
-  [key: string]: {
-    /** every controller of the api */
-    controllers?: UsersPermissionsPermissionsTreeControllers;
-  };
-}
+export interface UsersPermissionsPermissionsTree {[key: string]: {
+  /** every controller of the api */
+  controllers?: UsersPermissionsPermissionsTreeControllers;
+}}
 
 export type UsersPermissionsRoleRequestBody = {
   description?: string;
@@ -347,14 +341,14 @@ export interface UploadFile {
   width?: number;
 }
 
-export type DefaultFurtherInfoComponentType =
-  (typeof DefaultFurtherInfoComponentType)[keyof typeof DefaultFurtherInfoComponentType];
+export type DefaultFurtherInfoComponentType = typeof DefaultFurtherInfoComponentType[keyof typeof DefaultFurtherInfoComponentType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DefaultFurtherInfoComponentType = {
-  link: "link",
-  paper: "paper",
-  video: "video",
+  link: 'link',
+  paper: 'paper',
+  video: 'video',
 } as const;
 
 export interface DefaultFurtherInfoComponent {
@@ -366,13 +360,13 @@ export interface DefaultFurtherInfoComponent {
   url?: string;
 }
 
-export type TranslationsStoryTranslationComponentLocale =
-  (typeof TranslationsStoryTranslationComponentLocale)[keyof typeof TranslationsStoryTranslationComponentLocale];
+export type TranslationsStoryTranslationComponentLocale = typeof TranslationsStoryTranslationComponentLocale[keyof typeof TranslationsStoryTranslationComponentLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TranslationsStoryTranslationComponentLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export interface TranslationsStoryTranslationComponent {
@@ -422,7 +416,8 @@ export interface Story {
   description?: string;
   further_information?: DefaultFurtherInfoComponent[];
   image?: StoryImage;
-  location?: string;
+  latitude?: number;
+  longitude?: number;
   notes?: string;
   publishedAt?: string;
   title: string;
@@ -510,24 +505,24 @@ export type StoryDatasetsDataItemAttributesUpdatedBy = {
   data?: StoryDatasetsDataItemAttributesUpdatedByData;
 };
 
-export type StoryDatasetsDataItemAttributesType =
-  (typeof StoryDatasetsDataItemAttributesType)[keyof typeof StoryDatasetsDataItemAttributesType];
+export type StoryDatasetsDataItemAttributesType = typeof StoryDatasetsDataItemAttributesType[keyof typeof StoryDatasetsDataItemAttributesType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const StoryDatasetsDataItemAttributesType = {
-  Group: "Group",
-  Temporal: "Temporal",
-  Simple: "Simple",
-  "Temporal-Group": "Temporal-Group",
+  Group: 'Group',
+  Temporal: 'Temporal',
+  Simple: 'Simple',
+  'Temporal-Group': 'Temporal-Group',
 } as const;
 
-export type StoryDatasetsDataItemAttributesTranslationsItemLocale =
-  (typeof StoryDatasetsDataItemAttributesTranslationsItemLocale)[keyof typeof StoryDatasetsDataItemAttributesTranslationsItemLocale];
+export type StoryDatasetsDataItemAttributesTranslationsItemLocale = typeof StoryDatasetsDataItemAttributesTranslationsItemLocale[keyof typeof StoryDatasetsDataItemAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const StoryDatasetsDataItemAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type StoryDatasetsDataItemAttributesTranslationsItem = {
@@ -574,9 +569,7 @@ export type StoryDatasetsDataItemAttributesStory = {
   data?: StoryDatasetsDataItemAttributesStoryData;
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type StoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByData = {
   attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByDataAttributes;
@@ -587,13 +580,13 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributesUpdatedBy = {
   data?: StoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByData;
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale =
-  (typeof StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale)[keyof typeof StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale];
+export type StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale = typeof StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale[keyof typeof StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItem = {
@@ -620,7 +613,8 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributes = {
   description?: string;
   further_information?: StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItem[];
   image?: StoryDatasetsDataItemAttributesStoryDataAttributesImage;
-  location?: string;
+  latitude?: number;
+  longitude?: number;
   notes?: string;
   publishedAt?: string;
   title?: string;
@@ -629,8 +623,7 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributes = {
   updatedBy?: StoryDatasetsDataItemAttributesStoryDataAttributesUpdatedBy;
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByData = {
   attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByDataAttributes;
@@ -665,8 +658,7 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttribute
   width?: number;
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItemAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItemAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItem = {
   attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItemAttributes;
@@ -677,19 +669,18 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttribute
   data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItem[];
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributes =
-  {
-    children?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren;
-    createdAt?: string;
-    createdBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy;
-    files?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles;
-    name?: string;
-    parent?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent;
-    path?: string;
-    pathId?: number;
-    updatedAt?: string;
-    updatedBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributes = {
+  children?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren;
+  createdAt?: string;
+  createdBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy;
+  files?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles;
+  name?: string;
+  parent?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent;
+  path?: string;
+  pathId?: number;
+  updatedAt?: string;
+  updatedBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy;
+};
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderData = {
   attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributes;
@@ -700,156 +691,128 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttribute
   data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderData;
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem[];
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem[];
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem[];
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem[];
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes =
-  {
-    alternativeText?: string;
-    caption?: string;
-    createdAt?: string;
-    createdBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy;
-    ext?: string;
-    folder?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder;
-    folderPath?: string;
-    formats?: unknown;
-    hash?: string;
-    height?: number;
-    mime?: string;
-    name?: string;
-    previewUrl?: string;
-    provider?: string;
-    provider_metadata?: unknown;
-    related?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated;
-    size?: number;
-    updatedAt?: string;
-    updatedBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy;
-    url?: string;
-    width?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes = {
+  alternativeText?: string;
+  caption?: string;
+  createdAt?: string;
+  createdBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy;
+  ext?: string;
+  folder?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder;
+  folderPath?: string;
+  formats?: unknown;
+  hash?: string;
+  height?: number;
+  mime?: string;
+  name?: string;
+  previewUrl?: string;
+  provider?: string;
+  provider_metadata?: unknown;
+  related?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated;
+  size?: number;
+  updatedAt?: string;
+  updatedBy?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy;
+  url?: string;
+  width?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem =
-  {
-    attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem = {
+  attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren =
-  {
-    data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem[];
-  };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren = {
+  data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem[];
+};
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByData = {
   attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByDataAttributes;
@@ -860,14 +823,14 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttribute
   data?: StoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByData;
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType =
-  (typeof StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType)[keyof typeof StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType];
+export type StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType = typeof StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType[keyof typeof StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType = {
-  link: "link",
-  paper: "paper",
-  video: "video",
+  link: 'link',
+  paper: 'paper',
+  video: 'video',
 } as const;
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItem = {
@@ -879,9 +842,7 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformation
   url?: string;
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItemAttributes = {
-  [key: string]: any;
-};
+export type StoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItemAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItem = {
   attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItemAttributes;
@@ -892,9 +853,7 @@ export type StoryDatasetsDataItemAttributesStoryDataAttributesDatasets = {
   data?: StoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItem[];
 };
 
-export type StoryDatasetsDataItemAttributesStoryDataAttributesCreatedByDataAttributes = {
-  [key: string]: any;
-};
+export type StoryDatasetsDataItemAttributesStoryDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesStoryDataAttributesCreatedByData = {
   attributes?: StoryDatasetsDataItemAttributesStoryDataAttributesCreatedByDataAttributes;
@@ -929,9 +888,7 @@ export type StoryDatasetsDataItemAttributesLayersItem = {
   type?: string;
 };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByData = {
   attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByDataAttributes;
@@ -942,13 +899,13 @@ export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedB
   data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByData;
 };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale =
-  (typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale)[keyof typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale];
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale = typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale[keyof typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItem = {
@@ -974,24 +931,24 @@ export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributes = {
   updatedBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedBy;
 };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType =
-  (typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType)[keyof typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType];
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType = typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType[keyof typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType = {
-  Basic: "Basic",
-  Gradient: "Gradient",
-  Choropleth: "Choropleth",
-  Rangeland: "Rangeland",
+  Basic: 'Basic',
+  Gradient: 'Gradient',
+  Choropleth: 'Choropleth',
+  Rangeland: 'Rangeland',
 } as const;
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle =
-  (typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle)[keyof typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle];
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle = typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle[keyof typeof StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle = {
-  filled: "filled",
-  outline: "outline",
+  filled: 'filled',
+  outline: 'outline',
 } as const;
 
 export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItem = {
@@ -1039,166 +996,136 @@ export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedB
   data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByData;
 };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedBy = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRoles =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem[];
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRoles = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem[];
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    conditions?: unknown;
-    createdAt?: string;
-    createdBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    properties?: unknown;
-    role?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    subject?: string;
-    updatedAt?: string;
-    updatedBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes = {
+  action?: string;
+  actionParameters?: unknown;
+  conditions?: unknown;
+  createdAt?: string;
+  createdBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+  properties?: unknown;
+  role?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+  subject?: string;
+  updatedAt?: string;
+  updatedBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    code?: string;
-    createdAt?: string;
-    createdBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    description?: string;
-    name?: string;
-    permissions?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    updatedAt?: string;
-    updatedBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
-    users?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes = {
+  code?: string;
+  createdAt?: string;
+  createdBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+  description?: string;
+  name?: string;
+  permissions?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+  updatedAt?: string;
+  updatedBy?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
+  users?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData =
-  {
-    attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData = {
+  attributes?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedBy =
-  {
-    data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData;
-  };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedBy = {
+  data?: StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData;
+};
 
-export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type StoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type StoryDatasetsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
@@ -1264,19 +1191,20 @@ export type StoryRequestData = {
   description?: string;
   further_information?: DefaultFurtherInfoComponent[];
   image?: StoryRequestDataImage;
-  location?: string;
+  latitude?: number;
+  longitude?: number;
   notes?: string;
   title: string;
   translations?: TranslationsStoryTranslationComponent[];
 };
 
-export type TranslationsRangelandTranslationComponentLocale =
-  (typeof TranslationsRangelandTranslationComponentLocale)[keyof typeof TranslationsRangelandTranslationComponentLocale];
+export type TranslationsRangelandTranslationComponentLocale = typeof TranslationsRangelandTranslationComponentLocale[keyof typeof TranslationsRangelandTranslationComponentLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TranslationsRangelandTranslationComponentLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export interface TranslationsRangelandTranslationComponent {
@@ -1342,13 +1270,13 @@ export type RangelandEcoregionsDataItemAttributesUpdatedBy = {
   data?: RangelandEcoregionsDataItemAttributesUpdatedByData;
 };
 
-export type RangelandEcoregionsDataItemAttributesTranslationsItemLocale =
-  (typeof RangelandEcoregionsDataItemAttributesTranslationsItemLocale)[keyof typeof RangelandEcoregionsDataItemAttributesTranslationsItemLocale];
+export type RangelandEcoregionsDataItemAttributesTranslationsItemLocale = typeof RangelandEcoregionsDataItemAttributesTranslationsItemLocale[keyof typeof RangelandEcoregionsDataItemAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const RangelandEcoregionsDataItemAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type RangelandEcoregionsDataItemAttributesTranslationsItem = {
@@ -1394,9 +1322,7 @@ export type RangelandEcoregionsDataItemAttributes = {
   updatedBy?: RangelandEcoregionsDataItemAttributesUpdatedBy;
 };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesUpdatedByData = {
   attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesUpdatedByDataAttributes;
@@ -1407,13 +1333,13 @@ export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesUpdatedB
   data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesUpdatedByData;
 };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItemLocale =
-  (typeof RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItemLocale)[keyof typeof RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItemLocale];
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItemLocale = typeof RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItemLocale[keyof typeof RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesTranslationsItem = {
@@ -1426,8 +1352,7 @@ export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesEcoregio
   data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesEcoregionsDataItem[];
 };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesEcoregionsDataItemAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesEcoregionsDataItemAttributes = { [key: string]: any };
 
 export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesEcoregionsDataItem = {
   attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesEcoregionsDataItemAttributes;
@@ -1438,24 +1363,20 @@ export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedB
   data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByData;
 };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByData =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByData = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedBy =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByData;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedBy = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesUpdatedByData;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRoles =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItem[];
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRoles = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItem[];
+};
 
 export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributes = {
   blocked?: boolean;
@@ -1479,147 +1400,121 @@ export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedB
   id?: number;
 };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    code?: string;
-    createdAt?: string;
-    createdBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    description?: string;
-    name?: string;
-    permissions?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    updatedAt?: string;
-    updatedBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
-    users?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributes = {
+  code?: string;
+  createdAt?: string;
+  createdBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+  description?: string;
+  name?: string;
+  permissions?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+  updatedAt?: string;
+  updatedBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
+  users?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItem =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItem = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    conditions?: unknown;
-    createdAt?: string;
-    createdBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    properties?: unknown;
-    role?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    subject?: string;
-    updatedAt?: string;
-    updatedBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes = {
+  action?: string;
+  actionParameters?: unknown;
+  conditions?: unknown;
+  createdAt?: string;
+  createdBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+  properties?: unknown;
+  role?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+  subject?: string;
+  updatedAt?: string;
+  updatedBy?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByData =
-  {
-    attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByData = {
+  attributes?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedBy =
-  {
-    data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByData;
-  };
+export type RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedBy = {
+  data?: RangelandEcoregionsDataItemAttributesRangelandDataAttributesCreatedByDataAttributesCreatedByData;
+};
 
 export type RangelandEcoregionsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
@@ -1681,13 +1576,13 @@ export interface RangelandRequest {
   data: RangelandRequestData;
 }
 
-export type TranslationsLayerTranslationComponentLocale =
-  (typeof TranslationsLayerTranslationComponentLocale)[keyof typeof TranslationsLayerTranslationComponentLocale];
+export type TranslationsLayerTranslationComponentLocale = typeof TranslationsLayerTranslationComponentLocale[keyof typeof TranslationsLayerTranslationComponentLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TranslationsLayerTranslationComponentLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export interface TranslationsLayerTranslationComponent {
@@ -1697,24 +1592,24 @@ export interface TranslationsLayerTranslationComponent {
   title?: string;
 }
 
-export type DefaultLegendComponentType =
-  (typeof DefaultLegendComponentType)[keyof typeof DefaultLegendComponentType];
+export type DefaultLegendComponentType = typeof DefaultLegendComponentType[keyof typeof DefaultLegendComponentType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DefaultLegendComponentType = {
-  Basic: "Basic",
-  Gradient: "Gradient",
-  Choropleth: "Choropleth",
-  Rangeland: "Rangeland",
+  Basic: 'Basic',
+  Gradient: 'Gradient',
+  Choropleth: 'Choropleth',
+  Rangeland: 'Rangeland',
 } as const;
 
-export type DefaultLegendComponentItemsItemStyle =
-  (typeof DefaultLegendComponentItemsItemStyle)[keyof typeof DefaultLegendComponentItemsItemStyle];
+export type DefaultLegendComponentItemsItemStyle = typeof DefaultLegendComponentItemsItemStyle[keyof typeof DefaultLegendComponentItemsItemStyle];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DefaultLegendComponentItemsItemStyle = {
-  filled: "filled",
-  outline: "outline",
+  filled: 'filled',
+  outline: 'outline',
 } as const;
 
 export type DefaultLegendComponentItemsItem = {
@@ -1821,9 +1716,7 @@ export type LayerCreatedByData = {
   id?: number;
 };
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes = {
-  [key: string]: any;
-};
+export type LayerCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes = { [key: string]: any };
 
 export type LayerCreatedByDataAttributesRolesDataItemAttributesUsersDataItem = {
   attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
@@ -1834,9 +1727,7 @@ export type LayerCreatedByDataAttributesRolesDataItemAttributesUsers = {
   data?: LayerCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
 };
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type LayerCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type LayerCreatedByDataAttributesRolesDataItemAttributesUpdatedByData = {
   attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
@@ -1868,28 +1759,23 @@ export type LayerCreatedByDataAttributesRolesDataItemAttributes = {
   users?: LayerCreatedByDataAttributesRolesDataItemAttributesUsers;
 };
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData =
-  {
-    attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData = {
+  attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
-  {
-    data?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
-  };
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy = {
+  data?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
+};
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
-  { [key: string]: any };
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes = { [key: string]: any };
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
-  {
-    attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
-    id?: number;
-  };
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData = {
+  attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
+  id?: number;
+};
 
 export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole = {
   data?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
@@ -1908,23 +1794,18 @@ export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataIt
   updatedBy?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
 };
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData =
-  {
-    attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
-
-export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy =
-  {
-    data?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
-  };
-
-export type LayerCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes = {
-  [key: string]: any;
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData = {
+  attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
+  id?: number;
 };
+
+export type LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy = {
+  data?: LayerCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
+};
+
+export type LayerCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type LayerCreatedByDataAttributesRolesDataItemAttributesCreatedByData = {
   attributes?: LayerCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
@@ -1984,13 +1865,13 @@ export interface LayerRequest {
   data: LayerRequestData;
 }
 
-export type TranslationsEcoregionTranslationComponentLocale =
-  (typeof TranslationsEcoregionTranslationComponentLocale)[keyof typeof TranslationsEcoregionTranslationComponentLocale];
+export type TranslationsEcoregionTranslationComponentLocale = typeof TranslationsEcoregionTranslationComponentLocale[keyof typeof TranslationsEcoregionTranslationComponentLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TranslationsEcoregionTranslationComponentLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export interface TranslationsEcoregionTranslationComponent {
@@ -2056,13 +1937,13 @@ export type EcoregionRangelandDataAttributesUpdatedBy = {
   data?: EcoregionRangelandDataAttributesUpdatedByData;
 };
 
-export type EcoregionRangelandDataAttributesTranslationsItemLocale =
-  (typeof EcoregionRangelandDataAttributesTranslationsItemLocale)[keyof typeof EcoregionRangelandDataAttributesTranslationsItemLocale];
+export type EcoregionRangelandDataAttributesTranslationsItemLocale = typeof EcoregionRangelandDataAttributesTranslationsItemLocale[keyof typeof EcoregionRangelandDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EcoregionRangelandDataAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type EcoregionRangelandDataAttributesTranslationsItem = {
@@ -2108,9 +1989,7 @@ export type EcoregionRangelandDataAttributes = {
   updatedBy?: EcoregionRangelandDataAttributesUpdatedBy;
 };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesUpdatedByData = {
   attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesUpdatedByDataAttributes;
@@ -2121,13 +2000,13 @@ export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesUpdatedB
   data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesUpdatedByData;
 };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItemLocale =
-  (typeof EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItemLocale)[keyof typeof EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItemLocale];
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItemLocale = typeof EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItemLocale[keyof typeof EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslationsItem = {
@@ -2136,9 +2015,7 @@ export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesTranslat
   title?: string;
 };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesRangelandDataAttributes = {
-  [key: string]: any;
-};
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesRangelandDataAttributes = { [key: string]: any };
 
 export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesRangelandData = {
   attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesRangelandDataAttributes;
@@ -2153,24 +2030,20 @@ export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedB
   data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByData;
 };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByData =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByData = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedBy =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByData;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedBy = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesUpdatedByData;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRoles =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItem[];
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRoles = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItem[];
+};
 
 export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributes = {
   blocked?: boolean;
@@ -2194,147 +2067,121 @@ export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedB
   id?: number;
 };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    code?: string;
-    createdAt?: string;
-    createdBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    description?: string;
-    name?: string;
-    permissions?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    updatedAt?: string;
-    updatedBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
-    users?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes = {
+  code?: string;
+  createdAt?: string;
+  createdBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+  description?: string;
+  name?: string;
+  permissions?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+  updatedAt?: string;
+  updatedBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
+  users?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItem =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItem = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    conditions?: unknown;
-    createdAt?: string;
-    createdBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    properties?: unknown;
-    role?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    subject?: string;
-    updatedAt?: string;
-    updatedBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes = {
+  action?: string;
+  actionParameters?: unknown;
+  conditions?: unknown;
+  createdAt?: string;
+  createdBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+  properties?: unknown;
+  role?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+  subject?: string;
+  updatedAt?: string;
+  updatedBy?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByData =
-  {
-    attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByData = {
+  attributes?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedBy =
-  {
-    data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByData;
-  };
+export type EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedBy = {
+  data?: EcoregionRangelandDataAttributesEcoregionsDataItemAttributesCreatedByDataAttributesCreatedByData;
+};
 
 export type EcoregionRangelandDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
@@ -2396,14 +2243,14 @@ export interface EcoregionRequest {
   data: EcoregionRequestData;
 }
 
-export type TranslationsDatasetCategoryTranslationComponentLocale =
-  (typeof TranslationsDatasetCategoryTranslationComponentLocale)[keyof typeof TranslationsDatasetCategoryTranslationComponentLocale];
+export type TranslationsDatasetCategoryTranslationComponentLocale = typeof TranslationsDatasetCategoryTranslationComponentLocale[keyof typeof TranslationsDatasetCategoryTranslationComponentLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TranslationsDatasetCategoryTranslationComponentLocale = {
-  en: "en",
-  es: "es",
-  fr: "fr",
+  en: 'en',
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export interface TranslationsDatasetCategoryTranslationComponent {
@@ -2456,9 +2303,7 @@ export type DatasetCategoryDatasets = {
   data?: DatasetCategoryDatasetsDataItem[];
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetCategoryDatasetsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DatasetCategoryDatasetsDataItemAttributesUpdatedByData = {
   attributes?: DatasetCategoryDatasetsDataItemAttributesUpdatedByDataAttributes;
@@ -2469,24 +2314,24 @@ export type DatasetCategoryDatasetsDataItemAttributesUpdatedBy = {
   data?: DatasetCategoryDatasetsDataItemAttributesUpdatedByData;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesType =
-  (typeof DatasetCategoryDatasetsDataItemAttributesType)[keyof typeof DatasetCategoryDatasetsDataItemAttributesType];
+export type DatasetCategoryDatasetsDataItemAttributesType = typeof DatasetCategoryDatasetsDataItemAttributesType[keyof typeof DatasetCategoryDatasetsDataItemAttributesType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetCategoryDatasetsDataItemAttributesType = {
-  Group: "Group",
-  Temporal: "Temporal",
-  Simple: "Simple",
-  "Temporal-Group": "Temporal-Group",
+  Group: 'Group',
+  Temporal: 'Temporal',
+  Simple: 'Simple',
+  'Temporal-Group': 'Temporal-Group',
 } as const;
 
-export type DatasetCategoryDatasetsDataItemAttributesTranslationsItemLocale =
-  (typeof DatasetCategoryDatasetsDataItemAttributesTranslationsItemLocale)[keyof typeof DatasetCategoryDatasetsDataItemAttributesTranslationsItemLocale];
+export type DatasetCategoryDatasetsDataItemAttributesTranslationsItemLocale = typeof DatasetCategoryDatasetsDataItemAttributesTranslationsItemLocale[keyof typeof DatasetCategoryDatasetsDataItemAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetCategoryDatasetsDataItemAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type DatasetCategoryDatasetsDataItemAttributesTranslationsItem = {
@@ -2519,9 +2364,7 @@ export type DatasetCategoryDatasetsDataItemAttributes = {
   updatedBy?: DatasetCategoryDatasetsDataItemAttributesUpdatedBy;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByData = {
   attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByDataAttributes;
@@ -2532,13 +2375,13 @@ export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesUpdatedB
   data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesUpdatedByData;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale =
-  (typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale)[keyof typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale];
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale = typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale[keyof typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesTranslationsItem = {
@@ -2589,7 +2432,8 @@ export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributes = {
   description?: string;
   further_information?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItem[];
   image?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImage;
-  location?: string;
+  latitude?: number;
+  longitude?: number;
   notes?: string;
   publishedAt?: string;
   title?: string;
@@ -2603,231 +2447,191 @@ export type DatasetCategoryDatasetsDataItemAttributesStoryData = {
   id?: number;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesUpdatedByData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItemAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItemAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItem =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItemAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItem = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItemAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelated =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItem[];
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelated = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesRelatedDataItem[];
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolder =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolder = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParentData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes =
-  {
-    alternativeText?: string;
-    caption?: string;
-    createdAt?: string;
-    createdBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy;
-    ext?: string;
-    folder?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder;
-    folderPath?: string;
-    formats?: unknown;
-    hash?: string;
-    height?: number;
-    mime?: string;
-    name?: string;
-    previewUrl?: string;
-    provider?: string;
-    provider_metadata?: unknown;
-    related?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated;
-    size?: number;
-    updatedAt?: string;
-    updatedBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy;
-    url?: string;
-    width?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes = {
+  alternativeText?: string;
+  caption?: string;
+  createdAt?: string;
+  createdBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy;
+  ext?: string;
+  folder?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder;
+  folderPath?: string;
+  formats?: unknown;
+  hash?: string;
+  height?: number;
+  mime?: string;
+  name?: string;
+  previewUrl?: string;
+  provider?: string;
+  provider_metadata?: unknown;
+  related?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated;
+  size?: number;
+  updatedAt?: string;
+  updatedBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy;
+  url?: string;
+  width?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem[];
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItem[];
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributes =
-  {
-    children?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren;
-    createdAt?: string;
-    createdBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy;
-    files?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles;
-    name?: string;
-    parent?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent;
-    path?: string;
-    pathId?: number;
-    updatedAt?: string;
-    updatedBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributes = {
+  children?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren;
+  createdAt?: string;
+  createdBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy;
+  files?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFiles;
+  name?: string;
+  parent?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesParent;
+  path?: string;
+  pathId?: number;
+  updatedAt?: string;
+  updatedBy?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedBy;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem[];
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem[];
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem[];
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildren = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem[];
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByData;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesImageDataAttributesCreatedByData;
+};
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType =
-  (typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType)[keyof typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType];
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType = typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType[keyof typeof DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType =
-  {
-    link: "link",
-    paper: "paper",
-    video: "video",
-  } as const;
+export const DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItemType = {
+  link: 'link',
+  paper: 'paper',
+  video: 'video',
+} as const;
 
 export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherInformationItem = {
   content?: string;
@@ -2838,8 +2642,7 @@ export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesFurtherI
   url?: string;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItemAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItemAttributes = { [key: string]: any };
 
 export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItem = {
   attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItemAttributes;
@@ -2850,9 +2653,7 @@ export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesDatasets
   data?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesDatasetsDataItem[];
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesCreatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesCreatedByData = {
   attributes?: DatasetCategoryDatasetsDataItemAttributesStoryDataAttributesCreatedByDataAttributes;
@@ -2882,8 +2683,7 @@ export type DatasetCategoryDatasetsDataItemAttributesLayersItem = {
   type?: string;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByData = {
   attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByDataAttributes;
@@ -2894,23 +2694,21 @@ export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttribut
   data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesUpdatedByData;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale =
-  (typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale)[keyof typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale];
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale = typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale[keyof typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale =
-  {
-    es: "es",
-    fr: "fr",
-  } as const;
+export const DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale = {
+  es: 'es',
+  fr: 'fr',
+} as const;
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItem =
-  {
-    description?: string;
-    id?: number;
-    locale?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale;
-    title?: string;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItem = {
+  description?: string;
+  id?: number;
+  locale?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesTranslationsItemLocale;
+  title?: string;
+};
 
 export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributes = {
   config?: unknown;
@@ -2933,37 +2731,35 @@ export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerData = {
   id?: number;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType =
-  (typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType)[keyof typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType];
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType = typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType[keyof typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendType = {
-  Basic: "Basic",
-  Gradient: "Gradient",
-  Choropleth: "Choropleth",
-  Rangeland: "Rangeland",
+  Basic: 'Basic',
+  Gradient: 'Gradient',
+  Choropleth: 'Choropleth',
+  Rangeland: 'Rangeland',
 } as const;
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle =
-  (typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle)[keyof typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle];
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle = typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle[keyof typeof DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle =
-  {
-    filled: "filled",
-    outline: "outline",
-  } as const;
+export const DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle = {
+  filled: 'filled',
+  outline: 'outline',
+} as const;
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItem =
-  {
-    color?: string;
-    group?: string;
-    id?: number;
-    name?: string;
-    name_es?: string;
-    name_fr?: string;
-    style?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItem = {
+  color?: string;
+  group?: string;
+  id?: number;
+  name?: string;
+  name_es?: string;
+  name_fr?: string;
+  style?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegendItemsItemStyle;
+};
 
 export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesLegend = {
   id?: number;
@@ -2974,23 +2770,22 @@ export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttribut
   unit_fr?: string;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributes =
-  {
-    blocked?: boolean;
-    createdAt?: string;
-    createdBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedBy;
-    email?: string;
-    firstname?: string;
-    isActive?: boolean;
-    lastname?: string;
-    preferedLanguage?: string;
-    registrationToken?: string;
-    resetPasswordToken?: string;
-    roles?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRoles;
-    updatedAt?: string;
-    updatedBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedBy;
-    username?: string;
-  };
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributes = {
+  blocked?: boolean;
+  createdAt?: string;
+  createdBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedBy;
+  email?: string;
+  firstname?: string;
+  isActive?: boolean;
+  lastname?: string;
+  preferedLanguage?: string;
+  registrationToken?: string;
+  resetPasswordToken?: string;
+  roles?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRoles;
+  updatedAt?: string;
+  updatedBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedBy;
+  username?: string;
+};
 
 export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByData = {
   attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributes;
@@ -3001,170 +2796,138 @@ export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttribut
   data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByData;
 };
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRoles =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem[];
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
-  { [key: string]: any };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    conditions?: unknown;
-    createdAt?: string;
-    createdBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    properties?: unknown;
-    role?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    subject?: string;
-    updatedAt?: string;
-    updatedBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    code?: string;
-    createdAt?: string;
-    createdBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    description?: string;
-    name?: string;
-    permissions?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    updatedAt?: string;
-    updatedBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
-    users?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
-  { [key: string]: any };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData =
-  {
-    attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
-    id?: number;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedBy =
-  {
-    data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData;
-  };
-
-export type DatasetCategoryDatasetsDataItemAttributesCreatedByDataAttributes = {
-  [key: string]: any;
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
+  id?: number;
 };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesUpdatedByData;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRoles = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItem[];
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes = { [key: string]: any };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes = {
+  action?: string;
+  actionParameters?: unknown;
+  conditions?: unknown;
+  createdAt?: string;
+  createdBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+  properties?: unknown;
+  role?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+  subject?: string;
+  updatedAt?: string;
+  updatedBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes = {
+  code?: string;
+  createdAt?: string;
+  createdBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+  description?: string;
+  name?: string;
+  permissions?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+  updatedAt?: string;
+  updatedBy?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
+  users?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes = { [key: string]: any };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes = { [key: string]: any };
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData = {
+  attributes?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
+  id?: number;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedBy = {
+  data?: DatasetCategoryDatasetsDataItemAttributesLayersItemLayerDataAttributesCreatedByDataAttributesCreatedByData;
+};
+
+export type DatasetCategoryDatasetsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type DatasetCategoryDatasetsDataItemAttributesCreatedByData = {
   attributes?: DatasetCategoryDatasetsDataItemAttributesCreatedByDataAttributes;
@@ -3228,13 +2991,13 @@ export interface DatasetCategoryRequest {
   data: DatasetCategoryRequestData;
 }
 
-export type TranslationsDatasetTranslationComponentLocale =
-  (typeof TranslationsDatasetTranslationComponentLocale)[keyof typeof TranslationsDatasetTranslationComponentLocale];
+export type TranslationsDatasetTranslationComponentLocale = typeof TranslationsDatasetTranslationComponentLocale[keyof typeof TranslationsDatasetTranslationComponentLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TranslationsDatasetTranslationComponentLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export interface TranslationsDatasetTranslationComponent {
@@ -3275,9 +3038,7 @@ export interface DefaultLayerComponent {
   type?: string;
 }
 
-export type DefaultLayerComponentLayerDataAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DefaultLayerComponentLayerDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DefaultLayerComponentLayerDataAttributesUpdatedByData = {
   attributes?: DefaultLayerComponentLayerDataAttributesUpdatedByDataAttributes;
@@ -3288,13 +3049,13 @@ export type DefaultLayerComponentLayerDataAttributesUpdatedBy = {
   data?: DefaultLayerComponentLayerDataAttributesUpdatedByData;
 };
 
-export type DefaultLayerComponentLayerDataAttributesTranslationsItemLocale =
-  (typeof DefaultLayerComponentLayerDataAttributesTranslationsItemLocale)[keyof typeof DefaultLayerComponentLayerDataAttributesTranslationsItemLocale];
+export type DefaultLayerComponentLayerDataAttributesTranslationsItemLocale = typeof DefaultLayerComponentLayerDataAttributesTranslationsItemLocale[keyof typeof DefaultLayerComponentLayerDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DefaultLayerComponentLayerDataAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type DefaultLayerComponentLayerDataAttributesTranslationsItem = {
@@ -3304,24 +3065,24 @@ export type DefaultLayerComponentLayerDataAttributesTranslationsItem = {
   title?: string;
 };
 
-export type DefaultLayerComponentLayerDataAttributesLegendType =
-  (typeof DefaultLayerComponentLayerDataAttributesLegendType)[keyof typeof DefaultLayerComponentLayerDataAttributesLegendType];
+export type DefaultLayerComponentLayerDataAttributesLegendType = typeof DefaultLayerComponentLayerDataAttributesLegendType[keyof typeof DefaultLayerComponentLayerDataAttributesLegendType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DefaultLayerComponentLayerDataAttributesLegendType = {
-  Basic: "Basic",
-  Gradient: "Gradient",
-  Choropleth: "Choropleth",
-  Rangeland: "Rangeland",
+  Basic: 'Basic',
+  Gradient: 'Gradient',
+  Choropleth: 'Choropleth',
+  Rangeland: 'Rangeland',
 } as const;
 
-export type DefaultLayerComponentLayerDataAttributesLegendItemsItemStyle =
-  (typeof DefaultLayerComponentLayerDataAttributesLegendItemsItemStyle)[keyof typeof DefaultLayerComponentLayerDataAttributesLegendItemsItemStyle];
+export type DefaultLayerComponentLayerDataAttributesLegendItemsItemStyle = typeof DefaultLayerComponentLayerDataAttributesLegendItemsItemStyle[keyof typeof DefaultLayerComponentLayerDataAttributesLegendItemsItemStyle];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DefaultLayerComponentLayerDataAttributesLegendItemsItemStyle = {
-  filled: "filled",
-  outline: "outline",
+  filled: 'filled',
+  outline: 'outline',
 } as const;
 
 export type DefaultLayerComponentLayerDataAttributesLegendItemsItem = {
@@ -3368,8 +3129,7 @@ export type DefaultLayerComponentLayerDataAttributes = {
   updatedBy?: DefaultLayerComponentLayerDataAttributesUpdatedBy;
 };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesUpdatedByData = {
   attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesUpdatedByDataAttributes;
@@ -3406,130 +3166,107 @@ export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributes = {
   username?: string;
 };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes = { [key: string]: any };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem =
-  {
-    attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
-    id?: number;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem = {
+  attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItemAttributes;
+  id?: number;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers =
-  {
-    data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers = {
+  data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsersDataItem[];
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData =
-  {
-    attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData = {
+  attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy =
-  {
-    data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy = {
+  data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedByData;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem =
-  {
-    attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
-    id?: number;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem = {
+  attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes;
+  id?: number;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions =
-  {
-    data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions = {
+  data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItem[];
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData =
-  {
-    attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData = {
+  attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy =
-  {
-    data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy = {
+  data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedByData;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes = { [key: string]: any };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData =
-  {
-    attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
-    id?: number;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData = {
+  attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleDataAttributes;
+  id?: number;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole =
-  {
-    data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole = {
+  data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRoleData;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData =
-  {
-    attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData = {
+  attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy =
-  {
-    data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy = {
+  data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedByData;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes =
-  {
-    action?: string;
-    actionParameters?: unknown;
-    conditions?: unknown;
-    createdAt?: string;
-    createdBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
-    properties?: unknown;
-    role?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
-    subject?: string;
-    updatedAt?: string;
-    updatedBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributes = {
+  action?: string;
+  actionParameters?: unknown;
+  conditions?: unknown;
+  createdAt?: string;
+  createdBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesCreatedBy;
+  properties?: unknown;
+  role?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesRole;
+  subject?: string;
+  updatedAt?: string;
+  updatedBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissionsDataItemAttributesUpdatedBy;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData =
-  {
-    attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData = {
+  attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy =
-  {
-    data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy = {
+  data?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedByData;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes =
-  {
-    code?: string;
-    createdAt?: string;
-    createdBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
-    description?: string;
-    name?: string;
-    permissions?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
-    updatedAt?: string;
-    updatedBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
-    users?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
-  };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributes = {
+  code?: string;
+  createdAt?: string;
+  createdBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesCreatedBy;
+  description?: string;
+  name?: string;
+  permissions?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesPermissions;
+  updatedAt?: string;
+  updatedBy?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUpdatedBy;
+  users?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesRolesDataItemAttributesUsers;
+};
 
-export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesCreatedByData = {
   attributes?: DefaultLayerComponentLayerDataAttributesCreatedByDataAttributesCreatedByDataAttributes;
@@ -3558,14 +3295,15 @@ export type DatasetUpdatedBy = {
   data?: DatasetUpdatedByData;
 };
 
-export type DatasetType = (typeof DatasetType)[keyof typeof DatasetType];
+export type DatasetType = typeof DatasetType[keyof typeof DatasetType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetType = {
-  Group: "Group",
-  Temporal: "Temporal",
-  Simple: "Simple",
-  "Temporal-Group": "Temporal-Group",
+  Group: 'Group',
+  Temporal: 'Temporal',
+  Simple: 'Simple',
+  'Temporal-Group': 'Temporal-Group',
 } as const;
 
 export type DatasetStoryDataAttributes = {
@@ -3575,7 +3313,8 @@ export type DatasetStoryDataAttributes = {
   description?: string;
   further_information?: DatasetStoryDataAttributesFurtherInformationItem[];
   image?: DatasetStoryDataAttributesImage;
-  location?: string;
+  latitude?: number;
+  longitude?: number;
   notes?: string;
   publishedAt?: string;
   title?: string;
@@ -3627,13 +3366,13 @@ export type DatasetStoryDataAttributesUpdatedBy = {
   data?: DatasetStoryDataAttributesUpdatedByData;
 };
 
-export type DatasetStoryDataAttributesTranslationsItemLocale =
-  (typeof DatasetStoryDataAttributesTranslationsItemLocale)[keyof typeof DatasetStoryDataAttributesTranslationsItemLocale];
+export type DatasetStoryDataAttributesTranslationsItemLocale = typeof DatasetStoryDataAttributesTranslationsItemLocale[keyof typeof DatasetStoryDataAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetStoryDataAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type DatasetStoryDataAttributesTranslationsItem = {
@@ -3653,9 +3392,7 @@ export type DatasetStoryDataAttributesImage = {
   data?: DatasetStoryDataAttributesImageData;
 };
 
-export type DatasetStoryDataAttributesImageDataAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetStoryDataAttributesImageDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesImageDataAttributesUpdatedByData = {
   attributes?: DatasetStoryDataAttributesImageDataAttributesUpdatedByDataAttributes;
@@ -3666,9 +3403,7 @@ export type DatasetStoryDataAttributesImageDataAttributesUpdatedBy = {
   data?: DatasetStoryDataAttributesImageDataAttributesUpdatedByData;
 };
 
-export type DatasetStoryDataAttributesImageDataAttributesRelatedDataItemAttributes = {
-  [key: string]: any;
-};
+export type DatasetStoryDataAttributesImageDataAttributesRelatedDataItemAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesImageDataAttributesRelatedDataItem = {
   attributes?: DatasetStoryDataAttributesImageDataAttributesRelatedDataItemAttributes;
@@ -3707,8 +3442,7 @@ export type DatasetStoryDataAttributesImageDataAttributes = {
   width?: number;
 };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData = {
   attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByDataAttributes;
@@ -3719,8 +3453,7 @@ export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesUpd
   data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesUpdatedByData;
 };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesParentData = {
   attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesParentDataAttributes;
@@ -3758,89 +3491,75 @@ export type DatasetStoryDataAttributesImageDataAttributesFolderData = {
   id?: number;
 };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData =
-  {
-    attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData = {
+  attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy =
-  {
-    data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy = {
+  data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedByData;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes = { [key: string]: any };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem =
-  {
-    attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes;
-    id?: number;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem = {
+  attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItemAttributes;
+  id?: number;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated =
-  {
-    data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem[];
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated = {
+  data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelatedDataItem[];
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes = { [key: string]: any };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData =
-  {
-    attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes;
-    id?: number;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData = {
+  attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderDataAttributes;
+  id?: number;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder =
-  {
-    data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder = {
+  data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolderData;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData =
-  {
-    attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes;
-    id?: number;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData = {
+  attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByDataAttributes;
+  id?: number;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy =
-  {
-    data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy = {
+  data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedByData;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes =
-  {
-    alternativeText?: string;
-    caption?: string;
-    createdAt?: string;
-    createdBy?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy;
-    ext?: string;
-    folder?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder;
-    folderPath?: string;
-    formats?: unknown;
-    hash?: string;
-    height?: number;
-    mime?: string;
-    name?: string;
-    previewUrl?: string;
-    provider?: string;
-    provider_metadata?: unknown;
-    related?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated;
-    size?: number;
-    updatedAt?: string;
-    updatedBy?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy;
-    url?: string;
-    width?: number;
-  };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributes = {
+  alternativeText?: string;
+  caption?: string;
+  createdAt?: string;
+  createdBy?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesCreatedBy;
+  ext?: string;
+  folder?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesFolder;
+  folderPath?: string;
+  formats?: unknown;
+  hash?: string;
+  height?: number;
+  mime?: string;
+  name?: string;
+  previewUrl?: string;
+  provider?: string;
+  provider_metadata?: unknown;
+  related?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesRelated;
+  size?: number;
+  updatedAt?: string;
+  updatedBy?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesFilesDataItemAttributesUpdatedBy;
+  url?: string;
+  width?: number;
+};
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData = {
   attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByDataAttributes;
@@ -3851,8 +3570,7 @@ export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesCre
   data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesCreatedByData;
 };
 
-export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes =
-  { [key: string]: any };
+export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem = {
   attributes?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItemAttributes;
@@ -3863,9 +3581,7 @@ export type DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesChi
   data?: DatasetStoryDataAttributesImageDataAttributesFolderDataAttributesChildrenDataItem[];
 };
 
-export type DatasetStoryDataAttributesImageDataAttributesCreatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetStoryDataAttributesImageDataAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesImageDataAttributesCreatedByData = {
   attributes?: DatasetStoryDataAttributesImageDataAttributesCreatedByDataAttributes;
@@ -3876,14 +3592,14 @@ export type DatasetStoryDataAttributesImageDataAttributesCreatedBy = {
   data?: DatasetStoryDataAttributesImageDataAttributesCreatedByData;
 };
 
-export type DatasetStoryDataAttributesFurtherInformationItemType =
-  (typeof DatasetStoryDataAttributesFurtherInformationItemType)[keyof typeof DatasetStoryDataAttributesFurtherInformationItemType];
+export type DatasetStoryDataAttributesFurtherInformationItemType = typeof DatasetStoryDataAttributesFurtherInformationItemType[keyof typeof DatasetStoryDataAttributesFurtherInformationItemType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetStoryDataAttributesFurtherInformationItemType = {
-  link: "link",
-  paper: "paper",
-  video: "video",
+  link: 'link',
+  paper: 'paper',
+  video: 'video',
 } as const;
 
 export type DatasetStoryDataAttributesFurtherInformationItem = {
@@ -3904,9 +3620,7 @@ export type DatasetStoryDataAttributesDatasets = {
   data?: DatasetStoryDataAttributesDatasetsDataItem[];
 };
 
-export type DatasetStoryDataAttributesDatasetsDataItemAttributesUpdatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetStoryDataAttributesDatasetsDataItemAttributesUpdatedByDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesDatasetsDataItemAttributesUpdatedByData = {
   attributes?: DatasetStoryDataAttributesDatasetsDataItemAttributesUpdatedByDataAttributes;
@@ -3917,24 +3631,24 @@ export type DatasetStoryDataAttributesDatasetsDataItemAttributesUpdatedBy = {
   data?: DatasetStoryDataAttributesDatasetsDataItemAttributesUpdatedByData;
 };
 
-export type DatasetStoryDataAttributesDatasetsDataItemAttributesType =
-  (typeof DatasetStoryDataAttributesDatasetsDataItemAttributesType)[keyof typeof DatasetStoryDataAttributesDatasetsDataItemAttributesType];
+export type DatasetStoryDataAttributesDatasetsDataItemAttributesType = typeof DatasetStoryDataAttributesDatasetsDataItemAttributesType[keyof typeof DatasetStoryDataAttributesDatasetsDataItemAttributesType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetStoryDataAttributesDatasetsDataItemAttributesType = {
-  Group: "Group",
-  Temporal: "Temporal",
-  Simple: "Simple",
-  "Temporal-Group": "Temporal-Group",
+  Group: 'Group',
+  Temporal: 'Temporal',
+  Simple: 'Simple',
+  'Temporal-Group': 'Temporal-Group',
 } as const;
 
-export type DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItemLocale =
-  (typeof DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItemLocale)[keyof typeof DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItemLocale];
+export type DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItemLocale = typeof DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItemLocale[keyof typeof DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItemLocale];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItemLocale = {
-  es: "es",
-  fr: "fr",
+  es: 'es',
+  fr: 'fr',
 } as const;
 
 export type DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItem = {
@@ -3945,9 +3659,7 @@ export type DatasetStoryDataAttributesDatasetsDataItemAttributesTranslationsItem
   title?: string;
 };
 
-export type DatasetStoryDataAttributesDatasetsDataItemAttributesStoryDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetStoryDataAttributesDatasetsDataItemAttributesStoryDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesDatasetsDataItemAttributesStoryData = {
   attributes?: DatasetStoryDataAttributesDatasetsDataItemAttributesStoryDataAttributes;
@@ -3991,9 +3703,7 @@ export type DatasetStoryDataAttributesDatasetsDataItemAttributes = {
   updatedBy?: DatasetStoryDataAttributesDatasetsDataItemAttributesUpdatedBy;
 };
 
-export type DatasetStoryDataAttributesDatasetsDataItemAttributesLayersItemLayerDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetStoryDataAttributesDatasetsDataItemAttributesLayersItemLayerDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesDatasetsDataItemAttributesLayersItemLayerData = {
   attributes?: DatasetStoryDataAttributesDatasetsDataItemAttributesLayersItemLayerDataAttributes;
@@ -4004,9 +3714,7 @@ export type DatasetStoryDataAttributesDatasetsDataItemAttributesLayersItemLayer 
   data?: DatasetStoryDataAttributesDatasetsDataItemAttributesLayersItemLayerData;
 };
 
-export type DatasetStoryDataAttributesDatasetsDataItemAttributesCreatedByDataAttributes = {
-  [key: string]: any;
-};
+export type DatasetStoryDataAttributesDatasetsDataItemAttributesCreatedByDataAttributes = { [key: string]: any };
 
 export type DatasetStoryDataAttributesDatasetsDataItemAttributesCreatedByData = {
   attributes?: DatasetStoryDataAttributesDatasetsDataItemAttributesCreatedByDataAttributes;
@@ -4068,15 +3776,15 @@ export interface DatasetListResponse {
   meta?: DatasetListResponseMeta;
 }
 
-export type DatasetRequestDataType =
-  (typeof DatasetRequestDataType)[keyof typeof DatasetRequestDataType];
+export type DatasetRequestDataType = typeof DatasetRequestDataType[keyof typeof DatasetRequestDataType];
+
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const DatasetRequestDataType = {
-  Group: "Group",
-  Temporal: "Temporal",
-  Simple: "Simple",
-  "Temporal-Group": "Temporal-Group",
+  Group: 'Group',
+  Temporal: 'Temporal',
+  Simple: 'Simple',
+  'Temporal-Group': 'Temporal-Group',
 } as const;
 
 export type DatasetRequestDataStory = number | string;
@@ -4121,3 +3829,4 @@ export type ErrorDataOneOf = { [key: string]: any };
  * @nullable
  */
 export type ErrorData = ErrorDataOneOf | ErrorDataOneOfTwoItem[] | null;
+

--- a/cms/src/api/story/content-types/story/schema.json
+++ b/cms/src/api/story/content-types/story/schema.json
@@ -23,10 +23,17 @@
     "notes": {
       "type": "richtext"
     },
-    "location": {
-      "type": "string",
+    "latitude": {
+      "type": "float",
       "required": false,
-      "regex": "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?) [-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
+      "min": -90,
+      "max": 90
+    },
+    "longitude": {
+      "type": "float",
+      "required": false,
+      "min": -180,
+      "max": 180
     },
     "datasets": {
       "type": "relation",

--- a/cms/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/cms/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -21,7 +21,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-11-10T08:52:50.947Z"
+    "x-generation-date": "2026-05-06T13:38:48.238Z"
   },
   "servers": [
     {
@@ -271,8 +271,13 @@
                       "notes": {
                         "type": "string"
                       },
-                      "location": {
-                        "type": "string"
+                      "latitude": {
+                        "type": "number",
+                        "format": "float"
+                      },
+                      "longitude": {
+                        "type": "number",
+                        "format": "float"
                       },
                       "datasets": {
                         "type": "object",
@@ -2157,8 +2162,13 @@
                                     "notes": {
                                       "type": "string"
                                     },
-                                    "location": {
-                                      "type": "string"
+                                    "latitude": {
+                                      "type": "number",
+                                      "format": "float"
+                                    },
+                                    "longitude": {
+                                      "type": "number",
+                                      "format": "float"
                                     },
                                     "datasets": {
                                       "type": "object",
@@ -4695,8 +4705,13 @@
               "notes": {
                 "type": "string"
               },
-              "location": {
-                "type": "string"
+              "latitude": {
+                "type": "number",
+                "format": "float"
+              },
+              "longitude": {
+                "type": "number",
+                "format": "float"
               },
               "datasets": {
                 "type": "array",
@@ -4800,8 +4815,13 @@
           "notes": {
             "type": "string"
           },
-          "location": {
-            "type": "string"
+          "latitude": {
+            "type": "number",
+            "format": "float"
+          },
+          "longitude": {
+            "type": "number",
+            "format": "float"
           },
           "datasets": {
             "type": "object",
@@ -5348,8 +5368,13 @@
                                     "notes": {
                                       "type": "string"
                                     },
-                                    "location": {
-                                      "type": "string"
+                                    "latitude": {
+                                      "type": "number",
+                                      "format": "float"
+                                    },
+                                    "longitude": {
+                                      "type": "number",
+                                      "format": "float"
                                     },
                                     "datasets": {
                                       "type": "object",

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -1089,7 +1089,22 @@ export interface ApiStoryStory extends Schema.CollectionType {
     title: Attribute.String & Attribute.Required & Attribute.Unique;
     description: Attribute.RichText;
     notes: Attribute.RichText;
-    location: Attribute.String;
+    latitude: Attribute.Float &
+      Attribute.SetMinMax<
+        {
+          min: -90;
+          max: 90;
+        },
+        number
+      >;
+    longitude: Attribute.Float &
+      Attribute.SetMinMax<
+        {
+          min: -180;
+          max: 180;
+        },
+        number
+      >;
     datasets: Attribute.Relation<
       'api::story.story',
       'oneToMany',


### PR DESCRIPTION
## Summary
- Replace `Story.location` (regex-validated string `"lat lng"`) with two `float` fields `latitude` and `longitude`, bounded by valid ranges (-90/90, -180/180).
- Float type stores ~15 significant digits — enough for sub-meter pin precision (decimal default `(10,2)` truncated to 2 decimals).
- Regenerate CMS documentation, generated content types, and orval client types so `Story` exposes `latitude?: number` / `longitude?: number`.

DB column auto-migrates on Strapi restart; the old `location` column is dropped. No data loss — table empty.

## Test plan
- [x] Pull branch, restart Strapi (`cd cms && yarn develop`)
- [x] Open admin → Content Manager → Story → create entry with title + latitude (e.g. `37.188169`) + longitude (e.g. `-3.606669`), publish
- [x] Confirm admin rejects out-of-range values (lat > 90, lng > 180)
- [x] `curl http://localhost:1337/api/stories` and verify `attributes.latitude` / `attributes.longitude` return as numbers with full precision
- [x] In `client`, run `npm run check-types` and `npm run build` — both pass