### PR TITLE
fix(docker): provide pnpm in runner stages for prod images

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -9,7 +9,7 @@ ENV NODE_ENV=development
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 

--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -8,7 +8,7 @@ RUN apt-get update -y && \
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 
@@ -39,6 +39,8 @@ RUN pnpm build
 FROM node:20.5-bullseye-slim AS runner
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 

--- a/cms/Dockerfile
+++ b/cms/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
 
 ENV NODE_ENV=development
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app/
 

--- a/cms/Dockerfile.prod
+++ b/cms/Dockerfile.prod
@@ -14,7 +14,7 @@ RUN apt-get update -y && \
 
 ENV NODE_ENV=production
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 
@@ -45,6 +45,8 @@ RUN apt-get update -y && \
     apt-get clean
 
 ENV NODE_ENV=production
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Cloud Run deploys after the pnpm migration failed: container exited before binding to PORT.
- Root cause: prod runner stages only had `node`, not `pnpm`. `entrypoint.sh` calls `pnpm start` / `pnpm config-sync` → command not found → exit 127.
- Add `corepack enable && corepack prepare pnpm@10.33.0 --activate` to both runner stages.
- Pre-fetch pnpm at build time so cold starts don't have to download the binary.
- Apply same pre-fetch to dev images for consistency.

## Test plan
- [ ] CI builds + deploys client and cms successfully
- [ ] Cloud Run revisions reach READY state
- [ ] Container responds on PORT