### PR TITLE
fix(docker): bypass pnpm in prod entrypoint to fix Cloud Run boot

### DIFF
--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -40,8 +40,6 @@ FROM node:24.15.0-bookworm-slim AS runner
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-
 WORKDIR /app
 
 RUN addgroup --system --gid 1001 nodejs

--- a/client/entrypoint.sh
+++ b/client/entrypoint.sh
@@ -12,7 +12,7 @@ case "${NODE_ENV}" in
         ;;
     production)
         echo "Running Production Server"
-        exec pnpm start
+        exec node node_modules/next/dist/bin/next start
         ;;
     *)
         echo "Unknown NODE environment: \"${NODE_ENV}\""


### PR DESCRIPTION
## Summary
- Production entrypoint now calls `node node_modules/next/dist/bin/next start` directly instead of `pnpm start`.
- Drop corepack lines from runner stage — nothing in the runtime needs pnpm.

## Root cause
Cloud Run revisions on Node 24 (PR #143) were failing with:
```
Error: EACCES: permission denied, mkdir '/nonexistent/.cache/node/corepack/v1'
```
The runner stage creates `nextjs` with `adduser --system` (no home), so its `$HOME` resolves to `/nonexistent`. Node 24's corepack looks for its cache under `$HOME/.cache` and, finding nothing, tries to download pnpm on first invocation — `mkdir /nonexistent/.cache` fails, the process exits, the container never listens on PORT 3000, Cloud Run times out.

Bypassing pnpm at runtime sidesteps corepack entirely. pnpm stays in the builder stage where it installs deps and runs the Next build.

## Verified locally
Built `Dockerfile.prod` with `--platform=linux/amd64` and ran with `NODE_ENV=production PORT=3000`:
- Before fix: `EACCES … /nonexistent/.cache/node/corepack/v1` then exit
- After fix: `Next.js 14.2.35 ✓ Ready in 300ms`, `HTTP 307` from `/`

## Test plan
- [ ] CI builds + deploys client successfully
- [ ] Cloud Run revision reaches READY state and binds to PORT
- [ ] `/en`, `/es`, `/fr` load