### PR TITLE
fix(i18n): strip port from middleware redirect

### DIFF
--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -1,8 +1,24 @@
 import createMiddleware from "next-intl/middleware";
+import { NextRequest } from "next/server";
 
 import { routing } from "@/i18n/routing";
 
-export default createMiddleware(routing);
+const intlMiddleware = createMiddleware(routing);
+
+export default function middleware(request: NextRequest) {
+  const response = intlMiddleware(request);
+  const location = response.headers.get("location");
+  if (!location) return response;
+
+  const url = new URL(location);
+  const forwardedHost = request.headers.get("x-forwarded-host");
+  const forwardedProto = request.headers.get("x-forwarded-proto");
+  if (forwardedHost) url.host = forwardedHost;
+  if (forwardedProto) url.protocol = `${forwardedProto}:`;
+  url.port = "";
+  response.headers.set("location", url.toString());
+  return response;
+}
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary
Hotfix: root path `/` on staging hangs because middleware redirects to a URL with the container's internal port (`:3000`) instead of the public URL.

## Test plan
- [x] `pnpm check-types`, `pnpm lint`, `pnpm build`
- [ ] After deploy: `curl -sI https://staging.rangelandsdata.org/` returns `location` without `:3000`
- [ ] Browser navigation to `/` redirects to `/{locale}` and loads