### PR TITLE
fix(i18n): keep port in localhost middleware redirect

### DIFF
--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -13,9 +13,11 @@ export default function middleware(request: NextRequest) {
   const url = new URL(location);
   const forwardedHost = request.headers.get("x-forwarded-host");
   const forwardedProto = request.headers.get("x-forwarded-proto");
-  if (forwardedHost) url.host = forwardedHost;
+  if (forwardedHost) {
+    url.host = forwardedHost;
+    if (!forwardedHost.includes(":")) url.port = "";
+  }
   if (forwardedProto) url.protocol = `${forwardedProto}:`;
-  url.port = "";
   response.headers.set("location", url.toString());
   return response;
 }


### PR DESCRIPTION
## Summary
- Localhost dev redirects dropped `:3000` because Next.js dev injects `x-forwarded-host: localhost:3000` on every request, triggering the reverse-proxy branch in `middleware.ts`.
- Trust the forwarded host as-is when it already includes a port; only strip the port when the forwarded host is host-only (Cloud Run case where the proxy elides the standard 443).

## Test plan
- [x] `pnpm dev` — clicking "Explore Map" no longer 404s on `localhost`
- [x] `curl http://localhost:3000/` → `Location: /en` (relative; browser preserves origin)
- [x] `curl -H "x-forwarded-host: example.com" ...` → `https://example.com/en`
- [x] `curl -H "x-forwarded-host: example.com:8443" ...` → `https://example.com:8443/en`
- [ ] Production redirect via Cloud Run still serves public host without internal port leak (post-merge spot check)