### PR TITLE
fix(map): use best-available refinement strategy for raster tiles

### DIFF
--- a/client/src/components/map/layers/deck-layer/raster.tsx
+++ b/client/src/components/map/layers/deck-layer/raster.tsx
@@ -37,7 +37,7 @@ class RasterLayer {
       year: 2020,
       visible: visibility ?? true,
       opacity: opacity ?? 1,
-      refinementStrategy: "never",
+      refinementStrategy: "best-available",
       renderSubLayers: (subLayer) => {
         const {
           id: subLayerId,


### PR DESCRIPTION
## Summary
- Switch deck.gl raster `TileLayer` refinement strategy from `never` to `best-available` so lower-zoom tiles fill in while higher zooms load.

## Test plan
- [x] Zoom in/out on a raster layer; verify no blank tiles while panning/zooming.