### PR TITLE
feat(i18n): force English-only + fix legend group on non-en locales

### DIFF
--- a/client/src/containers/header/index.tsx
+++ b/client/src/containers/header/index.tsx
@@ -1,8 +1,5 @@
-import { Suspense } from "react";
-
 import { cn } from "@/lib/utils";
 import HeaderNavigation from "./navigation";
-import LanguageSelector from "../language-selector";
 
 const Header = () => {
   return (
@@ -13,10 +10,6 @@ const Header = () => {
     >
       <div className="mx-6 flex items-center justify-between gap-7">
         <HeaderNavigation />
-        <div className="h-5 w-px bg-white"></div>
-        <Suspense fallback={null}>
-          <LanguageSelector variant="dark" />
-        </Suspense>
       </div>
     </div>
   );

--- a/client/src/containers/home/header.tsx
+++ b/client/src/containers/home/header.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import LanguageSelector from "../language-selector";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { motion, useScroll, useTransform } from "motion/react";
-import { Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 const MIN_SCROLL = 150;
 
@@ -61,10 +60,6 @@ const Header = () => {
         <Link className="transition-colors duration-300 hover:text-brown-light" href="/map">
           {t("Explore map")}
         </Link>
-        <div className="h-5 w-px bg-brown-dark"></div>
-        <Suspense fallback={null}>
-          <LanguageSelector />
-        </Suspense>
       </motion.div>
     </motion.div>
   );

--- a/client/src/containers/language-selector/index.tsx
+++ b/client/src/containers/language-selector/index.tsx
@@ -44,7 +44,7 @@ const LanguageSelector = ({ className, variant = "light" }: LanguageSelectorProp
     router.push(path, { locale: nextLocale });
   };
 
-  const localeLabels: Record<Locale, string> = {
+  const localeLabels: Partial<Record<"en" | "es" | "fr", string>> = {
     en: t("English"),
     es: t("Spanish"),
     fr: t("French"),

--- a/client/src/i18n/routing.ts
+++ b/client/src/i18n/routing.ts
@@ -1,7 +1,8 @@
 import { defineRouting } from "next-intl/routing";
 
 export const DEFAULT_LOCALE = "en";
-export const LOCALES = ["en", "es", "fr"] as const;
+export const LOCALES = ["en"] as const;
+export const DISABLED_LOCALES = ["es", "fr"] as const;
 export type Locale = (typeof LOCALES)[number];
 
 export const routing = defineRouting({

--- a/client/src/lib/localized-query.ts
+++ b/client/src/lib/localized-query.ts
@@ -169,8 +169,7 @@ export const useGetLocalizedList = <T, E>(query: UseQueryResult<T, E>) => {
             : i[`name_${locale}` as keyof DefaultLegendComponentItemsItem];
 
         return {
-          color: i.color,
-          id: i.id,
+          ...i,
           name: legendItemName,
         };
       });

--- a/client/src/proxy.ts
+++ b/client/src/proxy.ts
@@ -1,11 +1,23 @@
 import createMiddleware from "next-intl/middleware";
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-import { routing } from "@/i18n/routing";
+import { DEFAULT_LOCALE, DISABLED_LOCALES, routing } from "@/i18n/routing";
 
 const intlMiddleware = createMiddleware(routing);
 
+const DISABLED_LOCALE_PATTERN = new RegExp(`^/(${DISABLED_LOCALES.join("|")})(/|$)`);
+
 export default function proxy(request: NextRequest) {
+  const disabledMatch = request.nextUrl.pathname.match(DISABLED_LOCALE_PATTERN);
+  if (disabledMatch) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = request.nextUrl.pathname.replace(
+      DISABLED_LOCALE_PATTERN,
+      `/${DEFAULT_LOCALE}$2`,
+    );
+    return NextResponse.redirect(redirectUrl);
+  }
+
   const response = intlMiddleware(request);
   const location = response.headers.get("location");
   if (!location) return response;


### PR DESCRIPTION
## Summary
- Fix legend item groups vanishing on `es`/`fr`: `useGetLocalizedList` in [`client/src/lib/localized-query.ts`](https://github.com/Vizzuality/global-rangelands-data-platform/blob/feat/force-english-only/client/src/lib/localized-query.ts) returned only `{ color, id, name }` for non-en locales, dropping `group`/`style`. Spread the original item and override `name` only.
- Lock the app to English: `LOCALES = ["en"]`, add `DISABLED_LOCALES = ["es","fr"]`, redirect `/es/*` and `/fr/*` to `/en/*` in [`client/src/proxy.ts`](https://github.com/Vizzuality/global-rangelands-data-platform/blob/feat/force-english-only/client/src/proxy.ts), remove `<LanguageSelector />` from home and app headers.
- Keep the `LanguageSelector` container in place (unused) in case locales are re-enabled later.

## Test plan
- [ ] `/es/map` and `/fr/map` — server redirects to `/en/map`.
- [ ] No language toggle in home or app header.