### PR TITLE
feat(data): add biodiversity hotspots processing notebook

### DIFF
--- a/data-processing/notebooks/11_biodiversity_hotspots.ipynb
+++ b/data-processing/notebooks/11_biodiversity_hotspots.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ca24530a",
+   "source": "# Biodiversity Hotspots\n\nProcessing the Biodiversity Hotspots dataset (version 2016.1). The dataset contains\n36 polygon regions representing Earth's biologically richest and most endangered terrestrial\nareas. Processing includes cleaning geometries and converting to mbtiles for upload to Mapbox.\n\n**Source:** [Zenodo](https://doi.org/10.5281/zenodo.3261807)\n\n**Citation:** Michael Hoffman, Kellee Koenig, Gill Bunting, Jennifer Costanza, & Williams, K. J. (2016). Biodiversity Hotspots (version 2016.1) (2016.1) [Data set]. Zenodo. https://doi.org/10.5281/zenodo.3261807\n\n**License:** CC BY-SA 4.0",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "395e8726",
+   "source": "## Setup",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "53ad7c08",
+   "source": "import json\nimport logging\nimport os\nimport subprocess\nimport time\nfrom pathlib import Path\n\nimport antimeridian\nimport boto3\nimport geopandas as gpd\nimport requests\nfrom dotenv import load_dotenv\n\nload_dotenv()\n\nlogger = logging.getLogger(__name__)\nlogger.setLevel(logging.INFO)\n\npath_raw = \"../data/raw/hotspots_2016_1\"\npath_out = \"../data/processed/biodiversity_hotspots\"\nos.makedirs(path_out, exist_ok=True)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "60e9992a",
+   "source": "def create_mbtiles(\n    source_path: Path,\n    output_path: Path,\n    layer_name: str,\n    opts: str,\n):\n    \"\"\"Use tippecanoe to create mbtiles from a GeoJSON file.\"\"\"\n    cmd = f\"tippecanoe -o {output_path} -l {layer_name} {opts} {source_path}\"\n    logger.info(f\"Running: {cmd}\")\n    r = subprocess.call(cmd, shell=True)\n    if r != 0:\n        raise RuntimeError(f\"tippecanoe failed with exit code {r}\")\n    return r\n\n\ndef upload_mbtiles(mbtiles_path: str, tileset_id: str, name: str):\n    \"\"\"Upload an mbtiles file to Mapbox using the Uploads API.\"\"\"\n    token = os.environ[\"MAPBOX_ACCESS_TOKEN\"]\n    username = os.environ[\"MAPBOX_USERNAME\"]\n    base_url = f\"https://api.mapbox.com/uploads/v1/{username}\"\n    full_tileset = f\"{username}.{tileset_id}\"\n\n    file_size_mb = os.path.getsize(mbtiles_path) / (1024 * 1024)\n    print(f\"Uploading {mbtiles_path} ({file_size_mb:.1f} MB) → {full_tileset}\")\n\n    resp = requests.post(f\"{base_url}/credentials\", params={\"access_token\": token})\n    resp.raise_for_status()\n    creds = resp.json()\n\n    s3 = boto3.client(\n        \"s3\",\n        aws_access_key_id=creds[\"accessKeyId\"],\n        aws_secret_access_key=creds[\"secretAccessKey\"],\n        aws_session_token=creds[\"sessionToken\"],\n        region_name=\"us-east-1\",\n    )\n    s3.upload_file(mbtiles_path, creds[\"bucket\"], creds[\"key\"])\n\n    resp = requests.post(\n        base_url,\n        params={\"access_token\": token},\n        json={\"url\": creds[\"url\"], \"tileset\": full_tileset, \"name\": name},\n    )\n    resp.raise_for_status()\n    upload_id = resp.json()[\"id\"]\n\n    while True:\n        time.sleep(5)\n        resp = requests.get(f\"{base_url}/{upload_id}\", params={\"access_token\": token})\n        resp.raise_for_status()\n        status = resp.json()\n        progress = status.get(\"progress\", 0)\n        print(f\"  progress: {progress:.0%}\", end=\"\")\n        if status.get(\"complete\"):\n            print(\" — done!\")\n            return status\n        if status.get(\"error\"):\n            print(f\"\\n  ERROR: {status['error']}\")\n            return status\n        print()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc9f042",
+   "source": "## Load data",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "91ab0764",
+   "source": "hotspots = gpd.read_file(\n    os.path.join(path_raw, \"hotspots_2016_1.shp\"), engine=\"pyogrio\", on_invalid=\"warn\"\n)\n\nprint(f\"Features: {len(hotspots)}\")\nprint(f\"CRS: {hotspots.crs}\")\nprint(f\"Columns: {list(hotspots.columns)}\")\nhotspots.head()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20160e81",
+   "source": "## Clean data",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "2baab42f",
+   "source": "if hotspots.crs and hotspots.crs.to_epsg() != 4326:\n    hotspots = hotspots.to_crs(epsg=4326)\n\ninvalid_count = (~hotspots.geometry.is_valid).sum()\nif invalid_count > 0:\n    print(f\"Fixing {invalid_count} invalid geometries\")\n    hotspots[\"geometry\"] = hotspots.geometry.make_valid()\n\nhotspots = hotspots[~hotspots.geometry.is_empty & hotspots.geometry.notna()]\nhotspots = hotspots.drop_duplicates(subset=\"NAME\")\n\nprint(f\"Clean features: {len(hotspots)}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7fd4588",
+   "source": "## Export to GeoJSON and fix antimeridian\n\nPolygons crossing the 180°/-180° line get rendered as spanning the entire globe in\nGeoJSON. We fix those features by splitting them at the antimeridian.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "303e1a43",
+   "source": "hotspots_geojson = os.path.join(path_out, \"biodiversity_hotspots.geojson\")\n\nhotspots.to_file(hotspots_geojson, driver=\"GeoJSON\")\n\n\ndef _crosses_antimeridian(feature):\n    \"\"\"Check if a feature's coordinates span the antimeridian.\"\"\"\n    def _extract_lons(coords):\n        if isinstance(coords[0], (int, float)):\n            return [coords[0]]\n        lons = []\n        for c in coords:\n            lons.extend(_extract_lons(c))\n        return lons\n\n    lons = _extract_lons(feature[\"geometry\"][\"coordinates\"])\n    if not lons:\n        return False\n    return max(lons) - min(lons) > 180\n\n\nwith open(hotspots_geojson) as f:\n    geojson = json.load(f)\n\nfixed_count = 0\nfor i, feature in enumerate(geojson[\"features\"]):\n    if _crosses_antimeridian(feature):\n        geojson[\"features\"][i] = antimeridian.fix_geojson(feature)\n        fixed_count += 1\n\nwith open(hotspots_geojson, \"w\") as f:\n    json.dump(geojson, f)\n\nprint(f\"Antimeridian: {fixed_count} features fixed, {len(geojson['features'])} total\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "672ad70f",
+   "source": "## Create mbtiles\n\nTippecanoe settings:\n- `-Z1 -z10`: zoom levels 1 through 10\n- `-B4`: base zoom 4 — all features guaranteed present at zoom 4+\n- `--drop-densest-as-needed`: drop features at low zooms to stay under the tile size limit\n- `--force`: overwrite existing mbtiles",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "23c6c144",
+   "source": "tippecanoe_opts = \" \".join([\n    \"--force\",\n    \"--read-parallel\",\n    \"-Z1\",\n    \"-z10\",\n    \"-B4\",\n    \"--drop-densest-as-needed\",\n    \"--maximum-tile-bytes=1500000\",\n])\n\ncreate_mbtiles(\n    hotspots_geojson,\n    os.path.join(path_out, \"biodiversity_hotspots.mbtiles\"),\n    \"biodiversity_hotspots\",\n    tippecanoe_opts,\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96d28cb5",
+   "source": "## Upload to Mapbox\n\nRequires `MAPBOX_ACCESS_TOKEN` (secret token with `uploads:read` and `uploads:write`\nscopes) and `MAPBOX_USERNAME` in `../.env`.\n\nEdit the `tileset_id` and `name` below before running.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "7a61fc86",
+   "source": "upload_mbtiles(\n    mbtiles_path=os.path.join(path_out, \"biodiversity_hotspots.mbtiles\"),\n    tileset_id=\"biodiversity_hotspots\",  # ← edit this\n    name=\"Biodiversity Hotspots\",        # ← edit this\n)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add notebook `11_biodiversity_hotspots.ipynb` to process the CEPF Biodiversity Hotspots v2016.1 shapefile
- Reads from `data/raw/hotspots_2016_1/`, cleans geometries (`make_valid`, handles unclosed rings via `on_invalid="warn"`), fixes antimeridian-crossing polygons, and exports GeoJSON + mbtiles (zoom 1–10)
- Includes Mapbox upload step (same pattern as notebook 10 / KBA)

## Test plan
- [ ] Run all cells in `11_biodiversity_hotspots.ipynb` end-to-end
- [ ] Verify output GeoJSON and mbtiles in `data/processed/biodiversity_hotspots/`
- [ ] Confirm mbtiles upload to Mapbox renders correctly