### PR TITLE
fix(ui): render unordered lists in RichText

### DIFF
--- a/client/src/components/ui/rich-text.tsx
+++ b/client/src/components/ui/rich-text.tsx
@@ -26,6 +26,11 @@ const RichText = ({ children, className }: RichTextProps) => {
               {props.children}
             </ol>
           ),
+          ul: (props) => (
+            <ul {...omit(props, "node")} className="ml-4 list-disc">
+              {props.children}
+            </ul>
+          ),
         }}
         remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
         rehypePlugins={[rehypeRaw]}


### PR DESCRIPTION
## Summary
- Add `ul` renderer to [`RichText`](https://github.com/Vizzuality/global-rangelands-data-platform/blob/fix/rich-text-ul-styling/client/src/components/ui/rich-text.tsx) with `ml-4 list-disc` — `ul` was unstyled (no bullets, no indent); only `ol` had a custom renderer

## Test plan
- [ ] manual on staging: open a dataset whose description (rendered via [`containers/datasets/info.tsx`](https://github.com/Vizzuality/global-rangelands-data-platform/blob/fix/rich-text-ul-styling/client/src/containers/datasets/info.tsx)) contains a markdown bullet list (`- item`) and confirm bullets + indentation render