### PR TITLE
feat(tiler): migrate GEE asset paths to ILRI project

### DIFF
--- a/cloud_functions/earth_engine_tiler/.gitignore
+++ b/cloud_functions/earth_engine_tiler/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 build
 credentials.json
-ee_credentials.json
+ee_credentials*.json
 .env

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/anthropogenic-biomes.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/anthropogenic-biomes.ts
@@ -4,7 +4,7 @@ import {EarthEngineUtils} from "../earth-engine-utils";
 
 export const AnthropogenicBiomes: CategoricalDataset = {
   assetPath: {
-    default: "projects/gmvad-grass/assets/a2000_global_ByteCompress"
+    default: "projects/my-project-ilri-57371/assets/GRASS/a2000_global_ByteCompress"
   },
 
   bandName: 'b1',

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-buffalo.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-buffalo.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockBuffalo: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Bf_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Bf_2015_Da"
     },
 
     bandName: 'b1',

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-cattle.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-cattle.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockCattle: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Ct_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Ct_2015_Da"
     },
 
     bandName: 'b1',

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-chicken.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-chicken.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockChicken: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Ch_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Ch_2015_Da"
 
     },
 

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-duck.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-duck.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockDuck: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Dk_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Dk_2015_Da"
 
     },
 

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-goat.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-goat.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockGoat: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Gt_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Gt_2015_Da"
     },
 
     bandName: 'b1',

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-horse.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-horse.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockHorse: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Ho_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Ho_2015_Da"
     },
 
     bandName: 'b1',

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-pig.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-pig.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockPig: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Pg_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Pg_2015_Da"
 
     },
 

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-sheep.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/gridded-livestock-sheep.ts
@@ -5,7 +5,7 @@ import { GriddedLivestockCommonStyles} from "./common-styles-utils";
 
 export const GriddedLivestockSheep: CategoricalDataset = {
     assetPath: {
-        default: "projects/gmvad-grass/assets/5_Sh_2015_Da"
+        default: "projects/my-project-ilri-57371/assets/GRASS/5_Sh_2015_Da"
     },
 
     bandName: 'b1',

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/intactness_qprime.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/intactness_qprime.ts
@@ -5,7 +5,7 @@ import {EarthEngineUtils} from "../earth-engine-utils";
 
 export const IntactnessQPrime: ContinuousDataset = {
   assetPath: {
-    default: "projects/gmvad-grass/assets/intactness/intactness_Qprime_2009"
+    default: "projects/my-project-ilri-57371/assets/GRASS/intactness_Qprime_2009"
   },
 
   vizParams: {

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/intactness_qslope.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/intactness_qslope.ts
@@ -4,7 +4,7 @@ import { EarthEngineUtils } from "../earth-engine-utils";
 
 export const IntactnessQSlope: ContinuousDataset = {
   assetPath: {
-    default: "projects/gmvad-grass/assets/intactness/intactness_Qslope_2009"
+    default: "projects/my-project-ilri-57371/assets/GRASS/intactness_Qslope_2009"
   },
 
   // The visualization parameters will be defined here

--- a/cloud_functions/earth_engine_tiler/src/geeAssets/livestock-production-systems.ts
+++ b/cloud_functions/earth_engine_tiler/src/geeAssets/livestock-production-systems.ts
@@ -4,7 +4,7 @@ import {EarthEngineUtils} from "../earth-engine-utils";
 
 export const LivestockProductionSystems: CategoricalDataset = {
   assetPath: {
-    default: "projects/gmvad-grass/assets/ps_cmb_ByteCompress"
+    default: "projects/my-project-ilri-57371/assets/GRASS/ps_cmb_ByteCompress"
   },
 
   bandName: 'b1',


### PR DESCRIPTION
## Summary
- Migrate 12 GEE asset paths from `projects/gmvad-grass/assets/` to `projects/my-project-ilri-57371/assets/GRASS/`
- Affected layers: gridded livestock (8 species), anthropogenic biomes, livestock production systems, intactness Q-prime and Q-slope
- Widen `.gitignore` to cover all `ee_credentials*.json` files

## Test plan
- [ ] Verify the ILRI service account has read access to the new asset paths
- [ ] Test tile rendering locally for affected layers
- [ ] Confirm `ee_credentials.json` uses the ILRI project credentials