### PR TITLE
fix(map): stop LandMark layer freeze and guard deck beforeId

### DIFF
--- a/client/src/components/map/layers/deck-layer/landmark-component.tsx
+++ b/client/src/components/map/layers/deck-layer/landmark-component.tsx
@@ -192,7 +192,7 @@ const LandmarkLayerComponent = ({
           getFillColor: [category],
           getLineColor: [category],
         },
-        binary: false,
+        binary: true,
         ...props,
       }),
     [
@@ -259,7 +259,7 @@ const LandmarkLayerComponent = ({
           getLineWidth: [category, hoveredFeatureId, selectedFeatureId],
           getPointRadius: [category],
         },
-        binary: false,
+        binary: true,
         ...props,
       }),
     [

--- a/client/src/components/map/provider.tsx
+++ b/client/src/components/map/provider.tsx
@@ -63,19 +63,39 @@ function useMapboxOverlay(
 
 export const DeckMapboxOverlayProvider = ({ children }: PropsWithChildren) => {
   const layersRef = useRef<any[]>([]);
+  const { default: map } = useMap();
 
   const OVERLAY = useMapboxOverlay({
     interleaved: true,
   });
+
+  // A layer's beforeId can point at a mapbox background layer that was already
+  // removed from the map (e.g. toggling the layer off unmounts it), which makes
+  // deck.gl's resolveLayerGroups call map.moveLayer on a nonexistent id and throw.
+  // Strip beforeId in that case so the layer is appended to the top instead.
+  const withValidBeforeId = useCallback(
+    (layers: any[]) => {
+      const mapInstance = map?.getMap?.();
+      if (!mapInstance) return layers;
+      return layers.map((layer) => {
+        const beforeId = layer?.props?.beforeId;
+        if (beforeId && !mapInstance.getLayer(beforeId)) {
+          return layer.clone({ beforeId: undefined });
+        }
+        return layer;
+      });
+    },
+    [map],
+  );
 
   const addLayer = useCallback(
     (layer: any) => {
       const newLayers = [...layersRef.current.filter((l) => l.id !== layer.id), layer];
 
       layersRef.current = newLayers;
-      return OVERLAY.setProps({ layers: newLayers });
+      return OVERLAY.setProps({ layers: withValidBeforeId(newLayers) });
     },
-    [OVERLAY],
+    [OVERLAY, withValidBeforeId],
   );
 
   const removeLayer = useCallback(
@@ -83,9 +103,9 @@ export const DeckMapboxOverlayProvider = ({ children }: PropsWithChildren) => {
       const newLayers = [...layersRef.current.filter((l) => l.id !== id)];
 
       layersRef.current = newLayers;
-      OVERLAY.setProps({ layers: newLayers });
+      OVERLAY.setProps({ layers: withValidBeforeId(newLayers) });
     },
-    [OVERLAY],
+    [OVERLAY, withValidBeforeId],
   );
 
   const context = useMemo(


### PR DESCRIPTION
## Summary
- Set `binary: true` on the LandMark poly and points `MVTLayer`s — with `binary: false` deck.gl parsed tiles to GeoJSON and tessellated thousands of complex land-boundary polygons with `earcut` **synchronously on the main thread**, freezing the page for ~20s on load of the "Community and Indigenous Land Rights" dataset. Binary mode moves parsing/tessellation into loaders.gl workers (deck.gl's default). Measured on the affected route: longest main-thread task ~20,664 ms → ~55 ms, earcut ~20,000 ms → ~42 ms, pan/zoom zero long tasks. `latest` tile URLs unchanged, so GFW auto-updates are preserved.
- Guard the deck/mapbox overlay in `provider.tsx` so a layer whose `beforeId` points at an already-removed mapbox layer has its `beforeId` stripped instead of throwing `Layer … does not exist` when toggling the layer off/on.

## Test plan

- [x] Open `/en/map?layers=all-categories,rangeland-systems&datasets=community-and-indigenous-land-rights,rangeland-systems` — the page does **not** freeze on load; the map is interactive within ~1s
- [x] LandMark polygons and points render with category colors (Indigenous Lands, Community Lands, Indicative)
- [x] Clicking a feature opens the tooltip populated with its properties (Identity, Government recognition, Documentation status, Land category)
- [x] Toggling the dataset off then on produces no `Layer … does not exist` error in the console
