### PR TITLE
fix(deps): clear earth_engine_tiler shell-quote crit and 3 advisories

### DIFF
--- a/SECURITY-DEFERRALS.md
+++ b/SECURITY-DEFERRALS.md
@@ -165,6 +165,12 @@ and a repo-specific v5 effort estimate are in **`CMS-VULN-ASSESSMENT.md`** (repo
 All four are pinned by `@google/earthengine@0.1.405`, which depends on the old
 `googleapis@92` → `google-auth-library@7` → `googleapis-common@5` → `uuid@8` chain.
 
+> **Update 2026-07-09** (branch `fix/deps/audit-2026-07-09`): the tiler's newly-surfaced
+> dev-tooling advisories were cleared — `shell-quote` 1.8.1→1.9.0 (critical, GHSA #626, via
+> `concurrently`), `form-data` 4.0.0→4.0.6 (via `@types/node-fetch`), `tmp` 0.0.33→0.2.6
+> (scoped override on `external-editor`), `js-yaml` 4.1.0→4.3.0 (via `eslint`). The
+> googleapis-tree deferrals below (incl. `uuid`) are unaffected and remain deferred.
+
 ### Why deferred
 
 - The clean fix is upgrading `@google/earthengine` to its current release, which is a
@@ -202,4 +208,4 @@ declared by this repository, so it is not fixable via the lockfile.
 
 ---
 
-_Last updated: 2026-07-07 — §1 (orval) resolved via orval 8.20.0 bump on branch `fix/orval-8-security`. Original audit: 2026-07-02, branch `fix/deps/audit-2026-07-02`._
+_Last updated: 2026-07-09 — §3 (earth_engine_tiler) dev-tooling advisories cleared on branch `fix/deps/audit-2026-07-09`. §1 (orval) resolved via orval 8.20.0 bump on branch `fix/orval-8-security`. Original audit: 2026-07-02, branch `fix/deps/audit-2026-07-02`._

--- a/cloud_functions/earth_engine_tiler/package-lock.json
+++ b/cloud_functions/earth_engine_tiler/package-lock.json
@@ -1691,6 +1691,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -2405,14 +2421,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3217,9 +3236,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3596,10 +3616,21 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -4228,15 +4259,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -4887,10 +4909,14 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5168,15 +5194,13 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/cloud_functions/earth_engine_tiler/package.json
+++ b/cloud_functions/earth_engine_tiler/package.json
@@ -41,6 +41,9 @@
     "google-auth-library": {
       "node-forge": "1.4.0",
       "jws": "4.0.1"
+    },
+    "external-editor": {
+      "tmp": "0.2.6"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bump `shell-quote` 1.8.1 → 1.9.0 in `earth_engine_tiler` (via `concurrently`) — clears the critical newline-escape advisory [#626](https://github.com/Vizzuality/global-rangelands-data-platform/security/dependabot/626)
- Bump `form-data` 4.0.0 → 4.0.6 (via `@types/node-fetch`) — fixes CRLF injection [#642](https://github.com/Vizzuality/global-rangelands-data-platform/security/dependabot/642)
- Bump `js-yaml` 4.1.0 → 4.3.0 (via `eslint`) — fixes merge-key DoS [#657](https://github.com/Vizzuality/global-rangelands-data-platform/security/dependabot/657)
- Add scoped `external-editor → tmp` override to 0.2.6 — fixes path traversal [#617](https://github.com/Vizzuality/global-rangelands-data-platform/security/dependabot/617); the patched version sits outside the parent's `^0.0.33` range, so an override is required
- Defer `uuid` [#613](https://github.com/Vizzuality/global-rangelands-data-platform/security/dependabot/613) — the only fix is a major 8→11 bump on runtime deps (`cloudevents`, `googleapis-common`) and the advisory path (`v3/v5/v6` with a `buf` arg) is unreachable here (callers use `v4()`); recorded in [`SECURITY-DEFERRALS.md`](https://github.com/Vizzuality/global-rangelands-data-platform/blob/fix/deps/audit-2026-07-09/SECURITY-DEFERRALS.md) §3
- All four fixed packages are dev-only transitives; no runtime dependency of the tiler changed
- Related to [GRASS-380](https://vizzuality.atlassian.net/browse/GRASS-380)


[GRASS-380]: https://vizzuality.atlassian.net/browse/GRASS-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ